### PR TITLE
fix: Sanitize seed data

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -1,8 +1,9 @@
 {
   "demons": [
     {
-      "name": "Agathion",
-      "evolvesTo": "Mokoi",
+      "name": "agathion",
+      "displayName": "Agathion",
+      "evolvesTo": "mokoi",
       "primaryElement": "Electric",
       "level": "1",
       "arcana": "Chariot",
@@ -39,7 +40,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -5 to hit, range 5 ft., one target. \u000bHit: 1d6 + 2 physical damage."
+          "description": "Melee attack: -5 to hit, range 5 ft., one target.\nHit: 1d6 + 2 physical damage."
         },
         {
           "name": "Zio (4 SP, 1 action)",
@@ -50,10 +51,11 @@
           "description": "A stalwart foresight aids an ally\u2019s defense. Choose a creature within range (90 feet range). For 1 minute, whenever a damage roll is made against the creature, it is rolled again, using whichever result is lower. You may target yourself with this Skill. If the creature is under the effects of Rakunda, instead that effect and the effect of this Skill are removed."
         }
       ],
-      "background": "A general term for familiars used by Judeo-Christian magicians, they are usually sealed away in bottles, rings, or talismans. They torment the target selected by the conjurer.\n"
+      "background": "A general term for familiars used by Judeo-Christian magicians, they are usually sealed away in bottles, rings, or talismans. They torment the target selected by the conjurer."
     },
     {
-      "name": "Arsene",
+      "name": "arsene",
+      "displayName": "Arsene",
       "evolvesTo": null,
       "primaryElement": "Curse",
       "level": "1",
@@ -90,7 +92,7 @@
       "traits": [
         {
           "name": "Third Eye",
-          "description": "Focus. Concentrate. You can see it. You gain the following benefits:\n \u2022 You make Proficiency checks made to search for hidden levers, hints, and secret passages with advantage.\n \u2022 Attacks made against you that deal Physical damage have disadvantage."
+          "description": "Focus. Concentrate. You can see it. You gain the following benefits:\n\u2022 You make Proficiency checks made to search for hidden levers, hints, and secret passages with advantage.\n\u2022 Attacks made against you that deal Physical damage have disadvantage."
         }
       ],
       "skills": [
@@ -100,18 +102,19 @@
         },
         {
           "name": "Cleave (2 HP, 1 action)",
-          "description": "With scythe or claw, you swipe and slash at a foe. Make a melee attack against a creature within range \u000b(-5 to hit, 5 feet). On a hit, the creature receives 1d10 + 2 physical damage."
+          "description": "With scythe or claw, you swipe and slash at a foe. Make a melee attack against a creature within range\n(-5 to hit, 5 feet). On a hit, the creature receives 1d10 + 2 physical damage."
         },
         {
           "name": "Eiha (4 SP, 1 action)",
-          "description": "Small tendrils of darkness slither from the earth and sting your target. Make a ranged attack against a creature within range (-5 to hit, 60 feet). On a hit, they receive \u000b1d8 + 2 curse damage."
+          "description": "Small tendrils of darkness slither from the earth and sting your target. Make a ranged attack against a creature within range (-5 to hit, 60 feet). On a hit, they receive\n1d8 + 2 curse damage."
         }
       ],
-      "background": "Ars\u00e8ne Lupin, sometimes known as Raoul, is a fictional gentleman thief created by Maurice Leblanc. He was known for targeting criminals or those who were much worse than himself, making him an anti-hero of sorts within his own stories. He might have been partly inspired by the French anarchist Marius Jacob.\n"
+      "background": "Ars\u00e8ne Lupin, sometimes known as Raoul, is a fictional gentleman thief created by Maurice Leblanc. He was known for targeting criminals or those who were much worse than himself, making him an anti-hero of sorts within his own stories. He might have been partly inspired by the French anarchist Marius Jacob."
     },
     {
-      "name": "Mandrake",
-      "evolvesTo": "Chernobog",
+      "name": "mandrake",
+      "displayName": "Mandrake",
+      "evolvesTo": "chernobog",
       "primaryElement": "Ailment",
       "level": "1",
       "arcana": "Death",
@@ -146,27 +149,28 @@
       "traits": [
         {
           "name": "Life Aid",
-          "description": "Your tactical prowess grants you immense support abilities:\n \u2022 The range of Healing and Support Skills used by you is increased by 15 feet. This does not affect Skills with a range of \u201cSelf\u201d.\n \u2022 Whenever Initiative ends, all allies that acted within that Initiative regain lost Hit Points and Spell Points equal to your Magic. This does not affect yourself.  "
+          "description": "Your tactical prowess grants you immense support abilities:\n\u2022 The range of Healing and Support Skills used by you is increased by 15 feet. This does not affect Skills with a range of \u201cSelf\u201d.\n\u2022 Whenever Initiative ends, all allies that acted within that Initiative regain lost Hit Points and Spell Points equal to your Magic. This does not affect yourself.  "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 1d4 + 2 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 1d4 + 2 physical damage."
         },
         {
           "name": "Energy Drop (4 SP, 1 action)",
-          "description": "A stimulating remedy opens one\u2019s eyes against emotional malady. Choose a creature within range \u000b(75 feet). That creature recovers from Confuse, Fear, Despair, Rage, and Brainwash (see \u201cConditions\u201d)."
+          "description": "A stimulating remedy opens one\u2019s eyes against emotional malady. Choose a creature within range\n(75 feet). That creature recovers from Confuse, Fear, Despair, Rage, and Brainwash (see \u201cConditions\u201d)."
         },
         {
           "name": "Pulinpa (5 SP, 1 action)",
           "description": "Tendrils of bewildering magic pierce a foe\u2019s mind to unsettle them. Make a ranged attack against a creature within range (-5 To hit, 60 feet range). On a hit, if the result of each d6 is 4 or higher, the target is inflicted with Confuse (see \u201cConditions\u201d)."
         }
       ],
-      "background": "A Mandrake, also known as a Mandragora, is a poisonous plant that grows from the graves of guilty dead men. In legend, if pulled from the ground, it makes a sound like the scream of a dying child which is so horrible it either deafens or kills the person pulling it. It was generally used in all kinds of potions that promised amazing properties such as invulnerability, invisibility or immunity to the undead.\n"
+      "background": "A Mandrake, also known as a Mandragora, is a poisonous plant that grows from the graves of guilty dead men. In legend, if pulled from the ground, it makes a sound like the scream of a dying child which is so horrible it either deafens or kills the person pulling it. It was generally used in all kinds of potions that promised amazing properties such as invulnerability, invisibility or immunity to the undead."
     },
     {
-      "name": "Pixie",
+      "name": "pixie",
+      "displayName": "Pixie",
       "evolvesTo": null,
       "primaryElement": "Healing",
       "level": "1",
@@ -204,13 +208,13 @@
       "traits": [
         {
           "name": "Static Electricity",
-          "description": "An overabundance of electrical power primes a foe for paralysis. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with Shock (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "An overabundance of electrical power primes a foe for paralysis. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with Shock (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Zio (4 SP, 1 action)",
@@ -221,10 +225,11 @@
           "description": "Warm, soft green glow stitches minor wounds on an ally. Choose a creature within range (90 ft). That creature regains 1d8 + 7 hit points."
         }
       ],
-      "background": "Fairies of English legend. They are also called Piskies and Puggsies. Pixies are sometimes said to be the elements of unbaptized children, or souls that have left their bodies. They are small enough to fit into the palm of your hand, but can grow bigger or smaller. Pixies live in groups. They love to dance and can be found dancing in a circle nearly every night. So-called \"fairy rings\" are said to mark the group where they hold their dances.\n"
+      "background": "Fairies of English legend. They are also called Piskies and Puggsies. Pixies are sometimes said to be the elements of unbaptized children, or souls that have left their bodies. They are small enough to fit into the palm of your hand, but can grow bigger or smaller. Pixies live in groups. They love to dance and can be found dancing in a circle nearly every night. So-called \"fairy rings\" are said to mark the group where they hold their dances."
     },
     {
-      "name": "Pyro Jack",
+      "name": "pyro-jack",
+      "displayName": "Pyro Jack",
       "evolvesTo": null,
       "primaryElement": "Fire",
       "level": "1",
@@ -263,28 +268,29 @@
       "traits": [
         {
           "name": "Thermal Conduct",
-          "description": "Conductive energies overheat a vulnerable foe. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with Burn (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "Conductive energies overheat a vulnerable foe. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with Burn (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Agi (4 SP, 1 action)",
-          "description": "You fling a mote of flames at a target within range. Make a ranged attack against a creature within range \u000b(-5 to hit, 60 feet). On a hit, they receive 1d8 + 2 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
+          "description": "You fling a mote of flames at a target within range. Make a ranged attack against a creature within range\n(-5 to hit, 60 feet). On a hit, they receive 1d8 + 2 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
         },
         {
           "name": "Dazzler (5 SP, 1 action)",
           "description": "A sparkling, disorienting light flashes before a foe. Make a ranged attack against a creature within range (-5 to hit, 60 feet). On a hit, if the result of each d6 is 2 or higher, the target is inflicted with Dizzy (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Pyro Jack is named after the fabled figure Jack-O'-Lantern. According to the earliest accounts of the tale, \"Stingy Jack\" was an Irish farmer who persuaded the devil not to take him to hell. When he was refused entry into heaven, he wandered the earth as a turnip-headed (or pumpkin-headed) soul who would come to be called \"Jack of the Lantern,\" or so says the legend. Jack-o'-lanterns are carved by children and enthusiasts alike on Halloween. The tradition can also be thought to help guide the lost soul himself.\n The legend, however, goes back further than the term itself. Jack-o'-lantern or some variation thereof was at the height of usage in 17th century Europe. Simply put, it meant \"the guy with the lantern.\" Later the term would almost exclusively be used as slang in reference to the will-o'-the-wisp phenomenon, or ignis fatuus, due to the appearance of a far off person carrying a lantern."
+      "background": "Pyro Jack is named after the fabled figure Jack-O'-Lantern. According to the earliest accounts of the tale, \"Stingy Jack\" was an Irish farmer who persuaded the devil not to take him to hell. When he was refused entry into heaven, he wandered the earth as a turnip-headed (or pumpkin-headed) soul who would come to be called \"Jack of the Lantern,\" or so says the legend. Jack-o'-lanterns are carved by children and enthusiasts alike on Halloween. The tradition can also be thought to help guide the lost soul himself.\n\nThe legend, however, goes back further than the term itself. Jack-o'-lantern or some variation thereof was at the height of usage in 17th century Europe. Simply put, it meant \"the guy with the lantern.\" Later the term would almost exclusively be used as slang in reference to the will-o'-the-wisp phenomenon, or ignis fatuus, due to the appearance of a far off person carrying a lantern."
     },
     {
-      "name": "Bicorn",
-      "evolvesTo": "Unicorn",
+      "name": "bicorn",
+      "displayName": "Bicorn",
+      "evolvesTo": "unicorn",
       "primaryElement": "Physical",
       "level": "2",
       "arcana": "Hermit",
@@ -320,7 +326,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -7 to hit, range 5 ft., one target. \u000bHit: 1d8 + 3 physical damage."
+          "description": "Melee attack: -7 to hit, range 5 ft., one target.\nHit: 1d8 + 3 physical damage."
         },
         {
           "name": "Lunge (2 HP, 1 action)",
@@ -328,13 +334,14 @@
         },
         {
           "name": "Tarunda (8 SP, 1 action)",
-          "description": "You place a minor hex upon a foe, lessening their impact. Choose a creature within range \u000b(90 feet range). For 1 minute, whenever that creature rolls dice for a damage roll, they roll again, using whichever result is lower.  If the creature is under the effects of Tarukaja, instead that effect and the effect of this Skill are removed."
+          "description": "You place a minor hex upon a foe, lessening their impact. Choose a creature within range\n(90 feet range). For 1 minute, whenever that creature rolls dice for a damage roll, they roll again, using whichever result is lower.  If the creature is under the effects of Tarukaja, instead that effect and the effect of this Skill are removed."
         }
       ],
-      "background": "Bicorn is a unholy unicorn with two sharp, spiraling horns on its forehead. If unicorns are considered holy, then bicorns are considered unholy, reviled as filthy beasts. The number 1 supposedly represents the purity of man, and 2 represents the seductions brought with the arrival of women. Bicorn supposedly represents the sin of adultery. Males are called bicorns, while females are called chichevaches (\"thin cows\"). It is said that the unicorn was born from a bicorn and once had two horns itself.\n"
+      "background": "Bicorn is a unholy unicorn with two sharp, spiraling horns on its forehead. If unicorns are considered holy, then bicorns are considered unholy, reviled as filthy beasts. The number 1 supposedly represents the purity of man, and 2 represents the seductions brought with the arrival of women. Bicorn supposedly represents the sin of adultery. Males are called bicorns, while females are called chichevaches (\"thin cows\"). It is said that the unicorn was born from a bicorn and once had two horns itself."
     },
     {
-      "name": "Cait Sith",
+      "name": "cait-sith",
+      "displayName": "Cait Sith",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "2",
@@ -374,26 +381,27 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -5 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: -5 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Agi (4 SP, 1 action)",
-          "description": "You fling a mote of flames at a target within range. Make a ranged attack against a creature within range \u000b(-5 to hit, 60 feet). On a hit, they receive 1d8 + 2 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
+          "description": "You fling a mote of flames at a target within range. Make a ranged attack against a creature within range\n(-5 to hit, 60 feet). On a hit, they receive 1d8 + 2 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
         },
         {
           "name": "Cleave (2 HP, 1 action)",
-          "description": "With scythe or claw, you swipe and slash at a foe. Make a melee attack against a creature within range \u000b(-5 to hit, 5 feet). On a hit, the creature receives 1d10 + 2 physical damage."
+          "description": "With scythe or claw, you swipe and slash at a foe. Make a melee attack against a creature within range\n(-5 to hit, 5 feet). On a hit, the creature receives 1d10 + 2 physical damage."
         },
         {
           "name": "Tarukaja (8 SP, 1 action)",
           "description": "Invigorating force emboldens an ally. Choose a creature within range (90 feet). For 1 minute, whenever that creature rolls dice for a damage roll, they roll again, using whichever result is higher. You may target yourself with this Skill. If the creature is under the effects of Tarunda, instead that effect and the effect of this Skill are removed."
         }
       ],
-      "background": "Cait Sith is a Fairy that takes the form of a cat. Its name means \"fairy cat.\" The Cait Sith can converse in human tongues and walk on two legs, making no sound as it moves. It normally lives as a cat that travels back and forth between the cat kingdom and the human world. It has a white star-shaped mark on its chest. The Cait Sith appears in Irish and Scottish legends and served as the model for Puss-in-Boots.\n"
+      "background": "Cait Sith is a Fairy that takes the form of a cat. Its name means \"fairy cat.\" The Cait Sith can converse in human tongues and walk on two legs, making no sound as it moves. It normally lives as a cat that travels back and forth between the cat kingdom and the human world. It has a white star-shaped mark on its chest. The Cait Sith appears in Irish and Scottish legends and served as the model for Puss-in-Boots."
     },
     {
-      "name": "Genbu",
-      "evolvesTo": "Seiryu",
+      "name": "genbu",
+      "displayName": "Genbu",
+      "evolvesTo": "seiryu",
       "primaryElement": "Ice, Wind",
       "level": "2",
       "arcana": "Temperance",
@@ -436,26 +444,27 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -5 to hit, range 5 ft., one target. \u000bHit: 1d6 + 2 physical damage."
+          "description": "Melee attack: -5 to hit, range 5 ft., one target.\nHit: 1d6 + 2 physical damage."
         },
         {
           "name": "Bufu (4 SP, 1 action)",
-          "description": "A mote of crippling frost envelops a target. Make a ranged attack against a creature within range\u000b(-5 to hit, 60 feet). On a hit, they receive 1d8 + 3 ice damage. If each d6 in the attack roll is a 4 or higher, the target is also Frozen (see \u201cConditions\u201d)."
+          "description": "A mote of crippling frost envelops a target. Make a ranged attack against a creature within range\n(-5 to hit, 60 feet). On a hit, they receive 1d8 + 3 ice damage. If each d6 in the attack roll is a 4 or higher, the target is also Frozen (see \u201cConditions\u201d)."
         },
         {
           "name": "Garu (3 SP, 1 action)",
-          "description": "A gust whips and strikes a foe, twisting them about. Make a ranged attack against a creature within range \u000b(-5 to hit, 60 feet). On a hit, they receive 1d8 + 3 wind damage."
+          "description": "A gust whips and strikes a foe, twisting them about. Make a ranged attack against a creature within range\n(-5 to hit, 60 feet). On a hit, they receive 1d8 + 3 wind damage."
         },
         {
           "name": "Sukukaja (8 SP, 1 action)",
           "description": "A second wind blows past your ally, allowing for them to make a swift response. Choose a creature within range (90 feet). For 1 minute, all attacks made by the creature are made with advantage, and all attacks made against the creature are made with disadvantage. You may target yourself with this Skill. If the creature is under the effects of Sukunda, instead that effect and the effect of this Skill are removed."
         }
       ],
-      "background": "The Xuan Wu, also known as Black Tortoise of the North, Black Warrior or simply the Black Tortoise is one of the Four Symbols of the Chinese Constellation (Si Xiang) along with Qing Long, Zhu Que and Bai Hu. It represents the north, the color black, winter and the water element. It is usually depicted as both a tortoise and a snake, specifically with the snake coiling around the tortoise. It is sometimes called the Black Tortoise of the North and is also known as Genbu in Japanese, Huy\u1ec1n V\u0169 in Vietnamese and Hyeonmu or Hyunmoo in Korean.\n Genbu is also a Persona only acquired through the mystic, hidden art of fusion.\n"
+      "background": "The Xuan Wu, also known as Black Tortoise of the North, Black Warrior or simply the Black Tortoise is one of the Four Symbols of the Chinese Constellation (Si Xiang) along with Qing Long, Zhu Que and Bai Hu. It represents the north, the color black, winter and the water element. It is usually depicted as both a tortoise and a snake, specifically with the snake coiling around the tortoise. It is sometimes called the Black Tortoise of the North and is also known as Genbu in Japanese, Huy\u1ec1n V\u0169 in Vietnamese and Hyeonmu or Hyunmoo in Korean.\n\nGenbu is also a Persona only acquired through the mystic, hidden art of fusion."
     },
     {
-      "name": "Incubus",
-      "evolvesTo": "Belphegor",
+      "name": "incubus",
+      "displayName": "Incubus",
+      "evolvesTo": "belphegor",
       "primaryElement": "Gun",
       "level": "2",
       "arcana": "Devil",
@@ -497,22 +506,23 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -5 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: -5 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Dream Needle (5 HP, 1 action)",
-          "description": "Envenomed darts induce lethargy into the foe. Make a ranged attack against a creature within range (-5 to hit, 30 feet). On a hit, the creature receives \u000b1d10 + 3 gun damage. If the result of each d6 is 4 or higher, the creature is afflicted with Sleep (see \u201cConditions\u201d)."
+          "description": "Envenomed darts induce lethargy into the foe. Make a ranged attack against a creature within range (-5 to hit, 30 feet). On a hit, the creature receives\n1d10 + 3 gun damage. If the result of each d6 is 4 or higher, the creature is afflicted with Sleep (see \u201cConditions\u201d)."
         },
         {
           "name": "Life Drain (5 SP, 1 action)",
-          "description": "You reach out, savoring life force from a foe. Make a ranged attack against a creature within range \u000b(-5 to hit, 30 feet). On a hit, the creature receives 6 almighty damage, and you 6 regain hit points."
+          "description": "You reach out, savoring life force from a foe. Make a ranged attack against a creature within range\n(-5 to hit, 30 feet). On a hit, the creature receives 6 almighty damage, and you 6 regain hit points."
         }
       ],
-      "background": "An incubus is a demon in male form supposed to lie upon sleeping women in order to have sexual intercourse with them, according to a number of mythological and legendary traditions. Its female counterpart is the succubus. They were either spawned by the legions of Hell or appeared as creatures of the night, just like vampires. An incubus may pursue sexual relations with a woman in order to father a child, as in the legend of Merlin.\n Religious tradition holds that repeated intercourse with an incubus or succubus may result in the deterioration of health or even death. In medieval times, the church would use incubi and succubi to explain sexual functions, which were taboo subjects.\n"
+      "background": "An incubus is a demon in male form supposed to lie upon sleeping women in order to have sexual intercourse with them, according to a number of mythological and legendary traditions. Its female counterpart is the succubus. They were either spawned by the legions of Hell or appeared as creatures of the night, just like vampires. An incubus may pursue sexual relations with a woman in order to father a child, as in the legend of Merlin.\n\nReligious tradition holds that repeated intercourse with an incubus or succubus may result in the deterioration of health or even death. In medieval times, the church would use incubi and succubi to explain sexual functions, which were taboo subjects."
     },
     {
-      "name": "Kelpie",
-      "evolvesTo": "Valkyrie",
+      "name": "kelpie",
+      "displayName": "Kelpie",
+      "evolvesTo": "valkyrie",
       "primaryElement": "Wind",
       "level": "2",
       "arcana": "Strength",
@@ -553,7 +563,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -7 to hit, range 5 ft., one target. \u000bHit: 1d8 + 2 physical damage."
+          "description": "Melee attack: -7 to hit, range 5 ft., one target.\nHit: 1d8 + 2 physical damage."
         },
         {
           "name": "Lunge (2 HP, 1 action)",
@@ -561,17 +571,18 @@
         },
         {
           "name": "Garu (3 SP, 1 action)",
-          "description": "A gust whips and strikes a foe, twisting them about. Make a ranged attack against a creature within range \u000b(-5 to hit, 60 feet). On a hit, they receive 1d8 + 2 wind damage."
+          "description": "A gust whips and strikes a foe, twisting them about. Make a ranged attack against a creature within range\n(-5 to hit, 60 feet). On a hit, they receive 1d8 + 2 wind damage."
         },
         {
           "name": "Sukukaja (8 SP, 1 action)",
           "description": "A second wind blows past your ally, allowing for them to make a swift response. Choose a creature within range (90 feet). For 1 minute, all attacks made by the creature are made with advantage, and all attacks made against the creature are made with disadvantage. You may target yourself with this Skill. If the creature is under the effects of Sukunda, instead that effect and the effect of this Skill are removed."
         }
       ],
-      "background": "In Celtic mythology, a kelpie is said to be a supernatural water horse that haunts rivers and lakes in Scotland and Ireland. Its mane is black, but its skin is said to be cold as death. It is said to lure mortals into water, specifically young children, into drowning so it can eat them. The kelpie tempts children to ride on its back, and once the victims fall for the trap, the kelpie's skin is said to become adhesive.\n"
+      "background": "In Celtic mythology, a kelpie is said to be a supernatural water horse that haunts rivers and lakes in Scotland and Ireland. Its mane is black, but its skin is said to be cold as death. It is said to lure mortals into water, specifically young children, into drowning so it can eat them. The kelpie tempts children to ride on its back, and once the victims fall for the trap, the kelpie's skin is said to become adhesive."
     },
     {
-      "name": "Saki Mitama",
+      "name": "saki-mitama",
+      "displayName": "Saki Mitama",
       "evolvesTo": null,
       "primaryElement": "Support",
       "level": "2",
@@ -613,11 +624,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Bufu (4 SP, 1 action)",
-          "description": "A mote of crippling frost envelops a target. Make a ranged attack against a creature within range \u000b(-5 to hit, 30 feet). On a hit, they receive 1d8 + 3 ice damage. If each d6 in the attack roll is a 4 or higher, the target is also Frozen (see \u201cConditions\u201d)."
+          "description": "A mote of crippling frost envelops a target. Make a ranged attack against a creature within range\n(-5 to hit, 30 feet). On a hit, they receive 1d8 + 3 ice damage. If each d6 in the attack roll is a 4 or higher, the target is also Frozen (see \u201cConditions\u201d)."
         },
         {
           "name": "Element Wall (5 SP, 1 action)",
@@ -628,10 +639,11 @@
           "description": "A stalwart foresight aids an ally\u2019s defense. Choose a creature within range (90 feet). For 1 minute, whenever a damage roll is made against the creature, it is rolled again, using whichever result is lower. You may target yourself with this Skill. If the creature is under the effects of Rakunda, instead that effect and the effect of this Skill are removed."
         }
       ],
-      "background": "In Japanese belief, Saki Mitama is a part of the soul that brings good fortune and blessings. It is said to bring prosperity in hunting, fishing and harvests, however some believe this is actually the purpose of Nigi Mitama.\n Saki Mitama is a very rare entity indeed, only able to be acquired through fusion of shadows/demons, a rare and hidden art only usable by trained professionals within the Cognitive World and other words in between.\n"
+      "background": "In Japanese belief, Saki Mitama is a part of the soul that brings good fortune and blessings. It is said to bring prosperity in hunting, fishing and harvests, however some believe this is actually the purpose of Nigi Mitama.\n\nSaki Mitama is a very rare entity indeed, only able to be acquired through fusion of shadows/demons, a rare and hidden art only usable by trained professionals within the Cognitive World and other words in between."
     },
     {
-      "name": "Silky",
+      "name": "silky",
+      "displayName": "Silky",
       "evolvesTo": null,
       "primaryElement": "Ice",
       "level": "2",
@@ -674,11 +686,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Bufu (4 SP, 1 action)",
-          "description": "A mote of crippling frost envelops a target. Make a ranged attack against a creature within range \u000b(-5 to hit, 30 feet). On a hit, they receive 1d8 + 2 ice damage. If each d6 in the attack roll is a 4 or higher, the target is also Frozen (see \u201cConditions\u201d)."
+          "description": "A mote of crippling frost envelops a target. Make a ranged attack against a creature within range\n(-5 to hit, 30 feet). On a hit, they receive 1d8 + 2 ice damage. If each d6 in the attack roll is a 4 or higher, the target is also Frozen (see \u201cConditions\u201d)."
         },
         {
           "name": "Dormina (5 SP, 1 action)",
@@ -689,11 +701,12 @@
           "description": "Warm, soft green glow stitches minor wounds on an ally. Choose a creature within range (90 ft). That creature regains 1d8 + 4 hit points."
         }
       ],
-      "background": "A Silky, also known as Silkie (Silkies for plural), is a female fae or spirit clothed in silk from the borders of Scotland, known to \"wear rustling silk as she does household chores\" and \"terrorizes lazy servants.\" Although usually helpful and valued, performing chores and guarding houses against harmful intruders, they can also be mischievous, leaving houses they inhabit in disarray. They were sometimes believed as the female version of Brownies.\n"
+      "background": "A Silky, also known as Silkie (Silkies for plural), is a female fae or spirit clothed in silk from the borders of Scotland, known to \"wear rustling silk as she does household chores\" and \"terrorizes lazy servants.\" Although usually helpful and valued, performing chores and guarding houses against harmful intruders, they can also be mischievous, leaving houses they inhabit in disarray. They were sometimes believed as the female version of Brownies."
     },
     {
-      "name": "Succubus",
-      "evolvesTo": "Lilim",
+      "name": "succubus",
+      "displayName": "Succubus",
+      "evolvesTo": "lilim",
       "primaryElement": "Ailment",
       "level": "2",
       "arcana": "Moon",
@@ -729,13 +742,13 @@
       "traits": [
         {
           "name": "Hollow Jester",
-          "description": "You seek out the weak-willed and the ailing pack. You gain the following benefits:\n \u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n \u2022 You may add half your character level (min 1) to the damage roll of any attack against a target afflicted with a Condition. You may add this bonus multiple times, once for each Condition the target is inflicted with."
+          "description": "You seek out the weak-willed and the ailing pack. You gain the following benefits:\n\u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n\u2022 You may add half your character level (min 1) to the damage roll of any attack against a target afflicted with a Condition. You may add this bonus multiple times, once for each Condition the target is inflicted with."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Dormina (5 SP, 1 action)",
@@ -746,11 +759,12 @@
           "description": "You erase all motes of strength for foes. Choose up to six creatures within range (90 feet). All effects of Tarukaja, Rakukaja, Sukukaja are removed from them."
         }
       ],
-      "background": "A Succubus is a demon or spirit from European folklore during the medieval ages, which takes the form of an attractive female to seduce men. Their male counterpart is the Incubus. They were either spawned by the legions of Hell or appeared as creatures of the night, just like vampires. They are believed to have sexual intercourse with sleeping men.\n They draw energy from men to sustain themselves, often until the point of exhaustion, the deterioration of health or the death of the victim. Lilith and her daughters, the Lilim, are considered succubi. Succubi encounters have also been theorized as an attempt to explain birth defects or sometimes adultery.\n"
+      "background": "A Succubus is a demon or spirit from European folklore during the medieval ages, which takes the form of an attractive female to seduce men. Their male counterpart is the Incubus. They were either spawned by the legions of Hell or appeared as creatures of the night, just like vampires. They are believed to have sexual intercourse with sleeping men.\n\nThey draw energy from men to sustain themselves, often until the point of exhaustion, the deterioration of health or the death of the victim. Lilith and her daughters, the Lilim, are considered succubi. Succubi encounters have also been theorized as an attempt to explain birth defects or sometimes adultery."
     },
     {
-      "name": "Angel",
-      "evolvesTo": "Archangel",
+      "name": "angel",
+      "displayName": "Angel",
+      "evolvesTo": "archangel",
       "primaryElement": "Bless",
       "level": "3",
       "arcana": "Justice",
@@ -792,11 +806,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 1d4 + 3 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 1d4 + 3 physical damage."
         },
         {
           "name": "Kouha (4 SP, 1 action)",
-          "description": "A wisp of light illuminates and strikes a target. Make a ranged attack against a creature within range \u000b(-5 to hit, 60 feet). On a hit, they receive 1d8 + 2 bless damage."
+          "description": "A wisp of light illuminates and strikes a target. Make a ranged attack against a creature within range\n(-5 to hit, 60 feet). On a hit, they receive 1d8 + 2 bless damage."
         },
         {
           "name": "Makajama (5 SP, 1 action)",
@@ -807,11 +821,12 @@
           "description": "You cleanse impurities of the heart. Choose up to six creatures within range (90 feet). All effects of Tarunda, Rakunda, Sukunda are removed from them."
         }
       ],
-      "background": "Angels are divine celestial beings that have been recorded in various religious lore, mainly Abrahamic, who faithfully serve God. The term \"angel\" comes from the greek word \"angelos\" meaning \"messenger,\" as a translation of their name in hebrew \"Malach,\" this term is used both to refer to the lowest rank of angels and the heavenly host as a whole. Angel, however, is not their name as a species, but rather a description of their task, as angels are best described as \"spirits.\" The origin of angels is up to debate, but some suggest that they were created on the second day of creation by God from either fire or light as a manifestation of his boundless love.\n"
+      "background": "Angels are divine celestial beings that have been recorded in various religious lore, mainly Abrahamic, who faithfully serve God. The term \"angel\" comes from the greek word \"angelos\" meaning \"messenger,\" as a translation of their name in hebrew \"Malach,\" this term is used both to refer to the lowest rank of angels and the heavenly host as a whole. Angel, however, is not their name as a species, but rather a description of their task, as angels are best described as \"spirits.\" The origin of angels is up to debate, but some suggest that they were created on the second day of creation by God from either fire or light as a manifestation of his boundless love."
     },
     {
-      "name": "Berith",
-      "evolvesTo": "Eligor",
+      "name": "berith",
+      "displayName": "Berith",
+      "evolvesTo": "eligor",
       "primaryElement": "Physical",
       "level": "3",
       "arcana": "Hierophant",
@@ -848,28 +863,29 @@
       "traits": [
         {
           "name": "Crisis Control",
-          "description": "You not only exploit weakness effectively, but know how to guard your own. You gain the following benefits:\n \u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n \u2022 You receive half as much damage from attacks against which you are Weak."
+          "description": "You not only exploit weakness effectively, but know how to guard your own. You gain the following benefits:\n\u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n\u2022 You receive half as much damage from attacks against which you are Weak."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -5 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: -5 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Agi (4 SP, 1 action)",
-          "description": "You fling a mote of flames at a target within range. Make a ranged attack against a creature within range \u000b(-5 to hit, 60 feet). On a hit, they receive 1d8 + 2 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
+          "description": "You fling a mote of flames at a target within range. Make a ranged attack against a creature within range\n(-5 to hit, 60 feet). On a hit, they receive 1d8 + 2 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
         },
         {
           "name": "Power Slash (5 HP, 1 action)",
-          "description": "A powerful stroke with a trained arm causes immense injury. Make a melee attack against a creature within range (-5 to hit, 5 feet). On a hit, the creature receives \u000b2d10 + 3 physical damage."
+          "description": "A powerful stroke with a trained arm causes immense injury. Make a melee attack against a creature within range (-5 to hit, 5 feet). On a hit, the creature receives\n2d10 + 3 physical damage."
         }
       ],
-      "background": "According to the writings in The Lesser Key of Solomon, Berith is the twenty-eighth demonic spirit listed in Ars Goetia. He is a great duke of Hell with twenty-six legions of demons under his command. He is depicted as a knight or soldier wearing red armor and a golden crown; according to other grimoires, his skin is also red. He rides a gigantic red horse and burns those without manners.\n In order to speak with him, the conjurer must wear a silver ring and hold it before their face. He gives true answers to all things past, present and future as long as he is asked, but when not answering questions he is a liar. He can turn any metal into gold, give dignities and confirm them. As an angel, Berith was prince of the order of cherubim.\n"
+      "background": "According to the writings in The Lesser Key of Solomon, Berith is the twenty-eighth demonic spirit listed in Ars Goetia. He is a great duke of Hell with twenty-six legions of demons under his command. He is depicted as a knight or soldier wearing red armor and a golden crown; according to other grimoires, his skin is also red. He rides a gigantic red horse and burns those without manners.\n\nIn order to speak with him, the conjurer must wear a silver ring and hold it before their face. He gives true answers to all things past, present and future as long as he is asked, but when not answering questions he is a liar. He can turn any metal into gold, give dignities and confirm them. As an angel, Berith was prince of the order of cherubim."
     },
     {
-      "name": "Hua-Po",
-      "evolvesTo": "Skadi",
+      "name": "hua-po",
+      "displayName": "Hua-Po",
+      "evolvesTo": "skadi",
       "primaryElement": "Fire",
       "level": "3",
       "arcana": "Hanged Man",
@@ -905,17 +921,17 @@
       "traits": [
         {
           "name": "Thermal Conduct",
-          "description": "Conductive energies overheat a vulnerable foe. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with Burn (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "Conductive energies overheat a vulnerable foe. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with Burn (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Agi (4 SP, 1 action)",
-          "description": "You fling a mote of flames at a target within range. Make a ranged attack against a creature within range \u000b(-5 to hit, 60 feet). On a hit, they receive 1d8 + 3 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
+          "description": "You fling a mote of flames at a target within range. Make a ranged attack against a creature within range\n(-5 to hit, 60 feet). On a hit, they receive 1d8 + 3 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
         },
         {
           "name": "Dormina (5 SP, 1 action)",
@@ -923,13 +939,15 @@
         },
         {
           "name": "Tarunda (8 SP, 1 action)",
-          "description": "You place a minor hex upon a foe, lessening their impact. Choose a creature within range \u000b(90 feet range). For 1 minute, whenever that creature rolls dice for a damage roll, they roll again, using whichever result is lower.  If the creature is under the effects of Tarukaja, instead that effect and the effect of this Skill are removed."
+          "description": "You place a minor hex upon a foe, lessening their impact. Choose a creature within range\n(90 feet range). For 1 minute, whenever that creature rolls dice for a damage roll, they roll again, using whichever result is lower.  If the creature is under the effects of Tarukaja, instead that effect and the effect of this Skill are removed."
         }
       ],
-      "background": "According to scripture Zi-bu-yu in Qing dynasty, Hua Po is a kind of tree spirit said to be formed from the disembodied souls of dead humans when three or more people hang themselves from the same tree. They appear as beautiful young girls that are dressed in white clothes but are much smaller than the average human. Although they cannot speak, it is said that they make sounds that are as beautiful as those of songbirds.\n"
+      "background": "According to scripture Zi-bu-yu in Qing dynasty, Hua Po is a kind of tree spirit said to be formed from the disembodied souls of dead humans when three or more people hang themselves from the same tree. They appear as beautiful young girls that are dressed in white clothes but are much smaller than the average human. Although they cannot speak, it is said that they make sounds that are as beautiful as those of songbirds."
     },
     {
-      "name": "Koropokkuru",
+      "name": "koropokkuru",
+      "displayName": "Koropokkuru",
+      "evolvesTo": "futsunushi",
       "level": "3",
       "arcana": "Hermit",
       "alignment": "Neutral Good",
@@ -964,17 +982,17 @@
       "traits": [
         {
           "name": "Cold-Blooded",
-          "description": "With reptilian cruelty, you freeze a foe. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with Freeze (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "With reptilian cruelty, you freeze a foe. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with Freeze (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Bufu (4 SP, 1 action)",
-          "description": "A mote of crippling frost envelops a target. Make a ranged attack against a creature within range \u000b(-5 to hit, 30 feet). On a hit, they receive 1d8 + 3 ice damage. If each d6 in the attack roll is a 4 or higher, the target is also Frozen (see \u201cConditions\u201d)."
+          "description": "A mote of crippling frost envelops a target. Make a ranged attack against a creature within range\n(-5 to hit, 30 feet). On a hit, they receive 1d8 + 3 ice damage. If each d6 in the attack roll is a 4 or higher, the target is also Frozen (see \u201cConditions\u201d)."
         },
         {
           "name": "Makajama (5 SP, 1 action)",
@@ -985,10 +1003,11 @@
           "description": "You decelerate a foe, slowing their ability to react or act. Choose a creature within range (90 feet). For 1 minute, all attacks made by the creature have disadvantage, and all attacks against the creature have advantage.  If the creature is under the effects of Sukukaja, instead that effect and the effect of this Skill are removed."
         }
       ],
-      "background": "Koropokkuru are a race of small people in Ainu folklore. The name is traditionally analyzed as a tripartite compound of kor or koro (\"butterbur plant\"), pok (\"under, below\"), and kur or kuru (\"person\") and interpreted to mean \"people below the leaves of the butterbur plant\" in the Ainu language.\n"
+      "background": "Koropokkuru are a race of small people in Ainu folklore. The name is traditionally analyzed as a tripartite compound of kor or koro (\"butterbur plant\"), pok (\"under, below\"), and kur or kuru (\"person\") and interpreted to mean \"people below the leaves of the butterbur plant\" in the Ainu language."
     },
     {
-      "name": "Mokoi",
+      "name": "mokoi",
+      "displayName": "Mokoi",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "3",
@@ -1025,7 +1044,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -5 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: -5 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Skull Cracker (6 HP, 1 action)",
@@ -1040,11 +1059,12 @@
           "description": "A sparkling, disorienting light flashes before a foe. Make a ranged attack against a creature within range (-5 to hit, 60 feet). On a hit, if the result of each d6 is 2 or higher, the target is inflicted with Dizzy (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Mokoi are spirits of evil in Australian Murngin folklore that live in the jungle and move at night. They are the reincarnation of the \"shadow soul\" of humans and kill those who use dark magic. They would also kidnap and eat children at night, sometimes causing war with humans.\n"
+      "background": "Mokoi are spirits of evil in Australian Murngin folklore that live in the jungle and move at night. They are the reincarnation of the \"shadow soul\" of humans and kill those who use dark magic. They would also kidnap and eat children at night, sometimes causing war with humans."
     },
     {
-      "name": "Obariyon",
-      "evolvesTo": "Nue",
+      "name": "obariyon",
+      "displayName": "Obariyon",
+      "evolvesTo": "nue",
       "primaryElement": "Gun",
       "level": "3",
       "arcana": "Fool",
@@ -1085,25 +1105,26 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 1d4 + 3 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 1d4 + 3 physical damage."
         },
         {
           "name": "Snap (3 HP, 1 action)",
-          "description": "A pinpoint, puncturing strike penetrates the opponent\u2019s defenses. Make a ranged attack against a creature within range (-5 to hit, 15 feet). On a hit, the creature receives \u000b1d10 + 3 gun damage."
+          "description": "A pinpoint, puncturing strike penetrates the opponent\u2019s defenses. Make a ranged attack against a creature within range (-5 to hit, 15 feet). On a hit, the creature receives\n1d10 + 3 gun damage."
         },
         {
           "name": "Lucky Punch (2 HP, 1 action)",
-          "description": "You take a random swing, letting destiny do the work. Make a melee attack against a creature within range (-5 to hit, 10 feet). A creature hit by this attack receives \u000b1d10 + 1d8 + 3 physical damage. This Skill scores a Critical hit if the result of each d6 in its attack roll is 5 or higher."
+          "description": "You take a random swing, letting destiny do the work. Make a melee attack against a creature within range (-5 to hit, 10 feet). A creature hit by this attack receives\n1d10 + 1d8 + 3 physical damage. This Skill scores a Critical hit if the result of each d6 in its attack roll is 5 or higher."
         },
         {
           "name": "Sukunda (8 SP, 1 action)",
           "description": "You decelerate a foe, slowing their ability to react or act. Choose a creature within range (90 feet). For 1 minute, all attacks made by the creature have disadvantage, and all attacks against the creature have advantage.  If the creature is under the effects of Sukukaja, instead that effect and the effect of this Skill are removed."
         }
       ],
-      "background": "The Obariyon is a Japanese \"piggyback demon\" from local folklore. While a person is walking along a woodland or grassy path, the Obariyon may jump out and attach itself to their back. While it cannot be seen, its weight can be felt by the person, and it becomes harder to walk. The Obariyon cannot be easily removed without the use of magic, but it is said if you can remove it and take it home, it will turn into many valuable gold coins.\n"
+      "background": "The Obariyon is a Japanese \"piggyback demon\" from local folklore. While a person is walking along a woodland or grassy path, the Obariyon may jump out and attach itself to their back. While it cannot be seen, its weight can be felt by the person, and it becomes harder to walk. The Obariyon cannot be easily removed without the use of magic, but it is said if you can remove it and take it home, it will turn into many valuable gold coins."
     },
     {
-      "name": "Slime",
+      "name": "slime",
+      "displayName": "Slime",
       "evolvesTo": null,
       "primaryElement": "Ailment",
       "level": "3",
@@ -1141,13 +1162,13 @@
       "traits": [
         {
           "name": "Foul Stench",
-          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -7 to hit, range 5 ft., one target. \u000bHit: 1d8 + 3 physical damage."
+          "description": "Melee attack: -7 to hit, range 5 ft., one target.\nHit: 1d8 + 3 physical damage."
         },
         {
           "name": "Lunge (2 HP, 1 action)",
@@ -1162,11 +1183,12 @@
           "description": "A swirling infusion of dark forces spark fear into a foe. Make a ranged attack against a creature within range (-5 to hit, 60 feet). On a hit, if the result of each d6 is 2 or higher, the target is inflicted with Fear (see \u201cConditions\u201d)."
         }
       ],
-      "background": "A slime, also commonly called ooze, are common types of monsters in many fantasy role-play games. True to their name, they don't usually have any distinct shape and appear as large masses of gelatinous fluid. Slimes and oozes vary between mediums, with some being intelligent and capable of assuming basic shapes with others being nothing more than brainless piles of goo that dissolve whatever matter becomes enveloped by their bodies.\n Like oozes, many slimes dwell underground, and most secrete an acid from their skin that dissolves flesh and other materials rapidly. In D&D, slimes are essentially blind, but more than make up for that with an ability called \"blindsight,\" which allows them to discern nearby objects and creatures without needing to see them visually.\n"
+      "background": "A slime, also commonly called ooze, are common types of monsters in many fantasy role-play games. True to their name, they don't usually have any distinct shape and appear as large masses of gelatinous fluid. Slimes and oozes vary between mediums, with some being intelligent and capable of assuming basic shapes with others being nothing more than brainless piles of goo that dissolve whatever matter becomes enveloped by their bodies.\n\nLike oozes, many slimes dwell underground, and most secrete an acid from their skin that dissolves flesh and other materials rapidly. In D&D, slimes are essentially blind, but more than make up for that with an ability called \"blindsight,\" which allows them to discern nearby objects and creatures without needing to see them visually."
     },
     {
-      "name": "Ame-no-Uzume",
-      "evolvesTo": "Kushinada",
+      "name": "ame-no-uzume",
+      "displayName": "Ame-no-Uzume",
+      "evolvesTo": "kushinada",
       "primaryElement": "Ice",
       "level": "4",
       "arcana": "Lovers",
@@ -1207,7 +1229,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Zio (4 SP, 1 action)",
@@ -1222,11 +1244,12 @@
           "description": "Spiraling angelic light envelops an ally to rejuvenate them. Choose a creature within range. That creature regains 3d8 + 4 hit points."
         }
       ],
-      "background": "Ame no Uzume, also known as Ame-no-Uzume-no-Mikoto, The Great Persuader, and The Heavenly Alarming Female, is the goddess of dawn, mirth, meditation, revelry and the arts in the Shinto religion of Japan, and the wife of Sarutahiko \u014ckami. Her name can also be pronounced as Ama-no-Uzume. She is also known as \u014cmiyanome-no-\u014ckami, an inari kami possibly due to her relationship with her husband.\n"
+      "background": "Ame no Uzume, also known as Ame-no-Uzume-no-Mikoto, The Great Persuader, and The Heavenly Alarming Female, is the goddess of dawn, mirth, meditation, revelry and the arts in the Shinto religion of Japan, and the wife of Sarutahiko \u014ckami. Her name can also be pronounced as Ama-no-Uzume. She is also known as \u014cmiyanome-no-\u014ckami, an inari kami possibly due to her relationship with her husband."
     },
     {
-      "name": "Apsaras",
-      "evolvesTo": "Fortuna",
+      "name": "apsaras",
+      "displayName": "Apsaras",
+      "evolvesTo": "fortuna",
       "primaryElement": "Support",
       "level": "4",
       "arcana": "Priestess",
@@ -1268,11 +1291,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Rebellion (5 SP, 1 action)",
-          "description": "Golden light of obstinance heightens an ally\u2019s ability to deliver punishment. Choose a creature within range \u000b(90 feet). For 1 minute, attacks the creature makes score a Critical hit if the result of each d6 is a 5 or higher."
+          "description": "Golden light of obstinance heightens an ally\u2019s ability to deliver punishment. Choose a creature within range\n(90 feet). For 1 minute, attacks the creature makes score a Critical hit if the result of each d6 is a 5 or higher."
         },
         {
           "name": "Element Wall (10 SP, 1 action)",
@@ -1280,14 +1303,15 @@
         },
         {
           "name": "Bufu (4 SP, 1 action)",
-          "description": "A mote of crippling frost envelops a target. Make a ranged attack against a creature within range \u000b(-5 to hit, 30 feet). On a hit, they receive 1d8 + 3 ice damage. If each d6 in the attack roll is a 4 or higher, the target is also Frozen (see \u201cConditions\u201d)."
+          "description": "A mote of crippling frost envelops a target. Make a ranged attack against a creature within range\n(-5 to hit, 30 feet). On a hit, they receive 1d8 + 3 ice damage. If each d6 in the attack roll is a 4 or higher, the target is also Frozen (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Apsaras (Sanskrit: \u0905\u092a\u094d\u0938\u0930\u093e) also known as Vidhya Dhari, according to Hindu and Buddhist mythology, are spirits that appear in the form of young, beautiful women who have mastered the fine art of celestial dance. They are the wives of Indra's servants, Gandharvas, and are known to entertain the gods and fallen heroes, dancing in the divine palaces to music made by their husbands. They are frequently equated with the water-elemental nymphs and naiads of Ancient Greece, and depictions of them can be seen in Cambodian and Balinese culture.\n"
+      "background": "Apsaras (Sanskrit: \u0905\u092a\u094d\u0938\u0930\u093e) also known as Vidhya Dhari, according to Hindu and Buddhist mythology, are spirits that appear in the form of young, beautiful women who have mastered the fine art of celestial dance. They are the wives of Indra's servants, Gandharvas, and are known to entertain the gods and fallen heroes, dancing in the divine palaces to music made by their husbands. They are frequently equated with the water-elemental nymphs and naiads of Ancient Greece, and depictions of them can be seen in Cambodian and Balinese culture."
     },
     {
-      "name": "Ippon-Datara",
-      "evolvesTo": "Hecatoncheires",
+      "name": "ippon-datara",
+      "displayName": "Ippon-Datara",
+      "evolvesTo": "hecatoncheires",
       "primaryElement": "Physical",
       "level": "4",
       "arcana": "Hermit",
@@ -1332,7 +1356,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -7 to hit, range 5 ft., one target. \u000bHit: 1d8 + 3 physical damage."
+          "description": "Melee attack: -7 to hit, range 5 ft., one target.\nHit: 1d8 + 3 physical damage."
         },
         {
           "name": "Sledgehammer (6 HP, 1 action)",
@@ -1343,10 +1367,11 @@
           "description": "Invigorating force emboldens an ally. Choose a creature within range (90 feet). For 1 minute, whenever that creature rolls dice for a damage roll, they roll again, using whichever result is higher. You may target yourself with this Skill. If the creature is under the effects of Tarunda, instead that effect and the effect of this Skill are removed."
         }
       ],
-      "background": "The Ippon-Datara (\u4e00\u672c\u8e0f\u97b4*)? is a rarely spotted youkai due to its innate shyness driving it away from urban areas. Hermitting itself in the mountains of Japan, it is best known to lurk in the mountains bordering the Wakayama and Nara prefectures, though there have been sightings within their immediate neighboring prefectures. Their method of locomotion is by hopping around and doing somersaults. While normally wanting nothing to do with humans, once a year, on December 20th, if a human and Ippon-Datara meet, they will squash the humans unfortunate enough underfoot, and is considered an unlucky day in those prefectures, and are urged to stay away from the mountains.\n"
+      "background": "The Ippon-Datara (\u4e00\u672c\u8e0f\u97b4*)? is a rarely spotted youkai due to its innate shyness driving it away from urban areas. Hermitting itself in the mountains of Japan, it is best known to lurk in the mountains bordering the Wakayama and Nara prefectures, though there have been sightings within their immediate neighboring prefectures. Their method of locomotion is by hopping around and doing somersaults. While normally wanting nothing to do with humans, once a year, on December 20th, if a human and Ippon-Datara meet, they will squash the humans unfortunate enough underfoot, and is considered an unlucky day in those prefectures, and are urged to stay away from the mountains."
     },
     {
-      "name": "Jack Frost",
+      "name": "jack-frost",
+      "displayName": "Jack Frost",
       "evolvesTo": null,
       "primaryElement": "Ice",
       "level": "4",
@@ -1388,11 +1413,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -5 to hit, range 5 ft., one target. \u000bHit: 1d6 + 2 physical damage."
+          "description": "Melee attack: -5 to hit, range 5 ft., one target.\nHit: 1d6 + 2 physical damage."
         },
         {
           "name": "Bufu (4 SP, 1 action)",
-          "description": "A mote of crippling frost envelops a target. Make a ranged attack against a creature within range \u000b(-5 to hit, 30 feet). On a hit, they receive 3d8 + 2 ice damage. If each d6 in the attack roll is a 4 or higher, the target is also Frozen (see \u201cConditions\u201d)."
+          "description": "A mote of crippling frost envelops a target. Make a ranged attack against a creature within range\n(-5 to hit, 30 feet). On a hit, they receive 3d8 + 2 ice damage. If each d6 in the attack roll is a 4 or higher, the target is also Frozen (see \u201cConditions\u201d)."
         },
         {
           "name": "Baisudi (4 SP, 1 action)",
@@ -1403,11 +1428,12 @@
           "description": "You expose a foe\u2019s weak points, allowing you to land harder hits. Choose a creature within range (90 feet). For 1 minute, whenever a damage roll is made against that creature, the attacker rolls again, using whichever result is higher.  If the creature is under the effects of Rakukaja, instead that effect and the effect of this Skill are removed."
         }
       ],
-      "background": "Jack Frost is a spirit originating from England. He is a snow elf who brings in cold weather during the winter and is thought to be responsible for the frost that forms on the windows of homes and buildings.\n"
+      "background": "Jack Frost is a spirit originating from England. He is a snow elf who brings in cold weather during the winter and is thought to be responsible for the frost that forms on the windows of homes and buildings."
     },
     {
-      "name": "Kodama",
-      "evolvesTo": "Sudama",
+      "name": "kodama",
+      "displayName": "Kodama",
+      "evolvesTo": "sudama",
       "primaryElement": "Psychic",
       "level": "4",
       "arcana": "Star",
@@ -1448,7 +1474,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Psi (4 SP, 1 action)",
@@ -1456,17 +1482,18 @@
         },
         {
           "name": "Garu (3 SP, 1 action)",
-          "description": "A gust whips and strikes a foe, twisting them about. Make a ranged attack against a creature within range \u000b(-5 to hit, 60 feet). On a hit, they receive 1d8 + 3 wind damage."
+          "description": "A gust whips and strikes a foe, twisting them about. Make a ranged attack against a creature within range\n(-5 to hit, 60 feet). On a hit, they receive 1d8 + 3 wind damage."
         },
         {
           "name": "Rakunda (8 SP, 1 action)",
           "description": "You expose a foe\u2019s weak points, allowing you to land harder hits. Choose a creature within range (90 feet). For 1 minute, whenever a damage roll is made against that creature, the attacker rolls again, using whichever result is higher.  If the creature is under the effects of Rakukaja, instead that effect and the effect of this Skill are removed."
         }
       ],
-      "background": "A Kodama (\u6728\u9b45) is a spirit from Japanese folklore, which is believed to live in certain trees. Cutting down a tree which houses a kodama is thought to bring misfortune, and such trees are often marked with shimenawa rope.\n"
+      "background": "A Kodama (\u6728\u9b45) is a spirit from Japanese folklore, which is believed to live in certain trees. Cutting down a tree which houses a kodama is thought to bring misfortune, and such trees are often marked with shimenawa rope."
     },
     {
-      "name": "Koppa Tengu",
+      "name": "koppa-tengu",
+      "displayName": "Koppa Tengu",
       "evolvesTo": null,
       "primaryElement": "Wind",
       "level": "4",
@@ -1509,11 +1536,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Garu (3 SP, 1 action)",
-          "description": "A gust whips and strikes a foe, twisting them about. Make a ranged attack against a creature within range \u000b(-5 to hit, 60 feet). On a hit, they receive 1d8 + 2 wind damage."
+          "description": "A gust whips and strikes a foe, twisting them about. Make a ranged attack against a creature within range\n(-5 to hit, 60 feet). On a hit, they receive 1d8 + 2 wind damage."
         },
         {
           "name": "Sukukaja (8 SP, 1 action)",
@@ -1524,10 +1551,11 @@
           "description": "The arcane art of irritation is infused within your goading and jeering, evoking frustration from a foe. Make a ranged attack against a creature within range (-5 to hit, 60 feet). On a hit, if the result of each d6 is 2 or higher, the target is inflicted with Rage (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Tengu are a species that originate from Japanese mythology. Those who became Tengu and had ignorant or cruel hearts would become ko-tengu (small tengu) and those that were knowledgeable would become dai-tengu (big tengu). The koppa-tengu or \"leaf Tengu\" are among the smallest of the kotengu family, possessing very little spiritual energy. It is sometimes said wolves that live an exceptionally long life will become koppa-tengu and later will change into a form closer to a Karasu Tengu. The koppa-tengu often act as retainers and messengers to larger tengu, especially the Tengu King: Sojobo, a Kurama Tengu.\n"
+      "background": "Tengu are a species that originate from Japanese mythology. Those who became Tengu and had ignorant or cruel hearts would become ko-tengu (small tengu) and those that were knowledgeable would become dai-tengu (big tengu). The koppa-tengu or \"leaf Tengu\" are among the smallest of the kotengu family, possessing very little spiritual energy. It is sometimes said wolves that live an exceptionally long life will become koppa-tengu and later will change into a form closer to a Karasu Tengu. The koppa-tengu often act as retainers and messengers to larger tengu, especially the Tengu King: Sojobo, a Kurama Tengu."
     },
     {
-      "name": "Kusi Mitama",
+      "name": "kusi-mitama",
+      "displayName": "Kusi Mitama",
       "evolvesTo": null,
       "primaryElement": "Healing",
       "level": "4",
@@ -1569,7 +1597,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Media (9 SP, 2 actions)",
@@ -1584,11 +1612,12 @@
           "description": "You form a draining barrier that protects an ally. When you use this Skill, choose Fire, Ice, Electric, Wind, Psychic, or Nuke. Choose a creature within range (90 feet). For the next three rounds, starting to count down at the end of this one, the creature is no longer Weak to the chosen damage type, and receives half as much damage from that type (this effect is independent from and stacks with Resist)."
         }
       ],
-      "background": "In Japanese belief, Kusi Mitama, romanized as Kushi Mitama, is an aspect of the human soul known as the \"wondrous soul,\" which appears together with Saki Mitama, the providing soul, which is the power behind the harvest. It is believed to have mysterious powers, to cause transformations and to be able to cure illnesses, as according to Shinto belief.\n"
+      "background": "In Japanese belief, Kusi Mitama, romanized as Kushi Mitama, is an aspect of the human soul known as the \"wondrous soul,\" which appears together with Saki Mitama, the providing soul, which is the power behind the harvest. It is believed to have mysterious powers, to cause transformations and to be able to cure illnesses, as according to Shinto belief."
     },
     {
-      "name": "Onmoraki",
-      "evolvesTo": "Thunderbird",
+      "name": "onmoraki",
+      "displayName": "Onmoraki",
+      "evolvesTo": "thunderbird",
       "primaryElement": "Curse",
       "level": "4",
       "arcana": "Moon",
@@ -1626,32 +1655,33 @@
       "traits": [
         {
           "name": "Foul Stench",
-          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Eiha (4 SP, 1 action)",
-          "description": "Small tendrils of darkness slither from the earth and sting your target. Make a ranged attack against a creature within range (-5 to hit, 60 feet). On a hit, they receive \u000b1d8 + 3 curse damage."
+          "description": "Small tendrils of darkness slither from the earth and sting your target. Make a ranged attack against a creature within range (-5 to hit, 60 feet). On a hit, they receive\n1d8 + 3 curse damage."
         },
         {
           "name": "Agi (4 SP, 1 action)",
-          "description": "You fling a mote of flames at a target within range. Make a ranged attack against a creature within range \u000b(-5 to hit, 60 feet). On a hit, they receive 1d8 + 3 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
+          "description": "You fling a mote of flames at a target within range. Make a ranged attack against a creature within range\n(-5 to hit, 60 feet). On a hit, they receive 1d8 + 3 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
         },
         {
           "name": "Pulinpa (5 SP, 1 action)",
           "description": "Tendrils of bewildering magic pierce a foe\u2019s mind to unsettle them. Make a ranged attack against a creature within range (-5 to hit, 60 feet range). On a hit, if the result of each d6 is 2 or higher, the target is inflicted with Confuse (see \u201cConditions\u201d)."
         }
       ],
-      "background": "An onmoraki is a bird-demon created from the spirits of freshly-dead corpses that appears in Shinto mythology. They resemble a black crane, and if a person is caught sleeping in a temple's sermon hall, the onmoraki will rebuke them while flapping its wings. Onmoraki are also said to shout the Degeneration Sutra in the household altar of priests who neglect to read their sutras.\n In modern Japanese art, the onmoraki will often take on the comical appearance of a roasted chicken. This is most likely due to the works of a eighteenth century artist, Toriyama Sekien.\n"
+      "background": "An onmoraki is a bird-demon created from the spirits of freshly-dead corpses that appears in Shinto mythology. They resemble a black crane, and if a person is caught sleeping in a temple's sermon hall, the onmoraki will rebuke them while flapping its wings. Onmoraki are also said to shout the Degeneration Sutra in the household altar of priests who neglect to read their sutras.\n\nIn modern Japanese art, the onmoraki will often take on the comical appearance of a roasted chicken. This is most likely due to the works of a eighteenth century artist, Toriyama Sekien."
     },
     {
-      "name": "Orpheus F",
-      "evolvesTo": "Thanatos",
+      "name": "orpheus-f",
+      "displayName": "Orpheus F",
+      "evolvesTo": "thanatos",
       "primaryElement": "Healing",
       "level": "4",
       "arcana": "Fool",
@@ -1693,26 +1723,27 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -7 to hit, range 5 ft., one target. \u000bHit: 1d8 + 2 physical damage."
+          "description": "Melee attack: -7 to hit, range 5 ft., one target.\nHit: 1d8 + 2 physical damage."
         },
         {
           "name": "Neo Cadenza (32 SP, 2 actions)",
-          "description": "Orpheus plays a magical, enchanting melody to support the party\u2019s rush. Choose up to six creatures within range (90 feet). Those creatures regain \u000b1d8 + 4 hit points. Each of those creatures gain the effects of Tarukaja and Rakukaja."
+          "description": "Orpheus plays a magical, enchanting melody to support the party\u2019s rush. Choose up to six creatures within range (90 feet). Those creatures regain\n1d8 + 4 hit points. Each of those creatures gain the effects of Tarukaja and Rakukaja."
         },
         {
           "name": "Agi (4 SP, 1 action)",
-          "description": "You fling a mote of flames at a target within range. Make a ranged attack against a creature within range \u000b(-5 to hit, 60 feet). On a hit, they receive 1d8 + 2 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
+          "description": "You fling a mote of flames at a target within range. Make a ranged attack against a creature within range\n(-5 to hit, 60 feet). On a hit, they receive 1d8 + 2 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
         },
         {
           "name": "Tarunda (8 SP, 1 action)",
-          "description": "You place a minor hex upon a foe, lessening their impact. Choose a creature within range \u000b(90 feet range). For 1 minute, whenever that creature rolls dice for a damage roll, they roll again, using whichever result is lower.  If the creature is under the effects of Tarukaja, instead that effect and the effect of this Skill are removed."
+          "description": "You place a minor hex upon a foe, lessening their impact. Choose a creature within range\n(90 feet range). For 1 minute, whenever that creature rolls dice for a damage roll, they roll again, using whichever result is lower.  If the creature is under the effects of Tarukaja, instead that effect and the effect of this Skill are removed."
         }
       ],
-      "background": "In Greek mythology, Orpheus was the son of Thracian king Oeagrus and the muse Calliope (some versions have Orpheus' father as the god Apollo). Apollo, fond of Orpheus, gave him a small golden lyre, which he quickly mastered. Taught to sing verses by his mother, Orpheus was so skilled at making music that he was called \"Master of Strings\" and \"Father of Songs,\" capable of such music that even rocks and animals would be compelled to dance.\n This version of Orpheus, although bearing the same concept as the male counterpart, now sports longer brown hair, a golden-colored torso instead of a platinum one the male Orpheus adorns and a giant heart-shaped lyre.\n"
+      "background": "In Greek mythology, Orpheus was the son of Thracian king Oeagrus and the muse Calliope (some versions have Orpheus' father as the god Apollo). Apollo, fond of Orpheus, gave him a small golden lyre, which he quickly mastered. Taught to sing verses by his mother, Orpheus was so skilled at making music that he was called \"Master of Strings\" and \"Father of Songs,\" capable of such music that even rocks and animals would be compelled to dance.\n\nThis version of Orpheus, although bearing the same concept as the male counterpart, now sports longer brown hair, a golden-colored torso instead of a platinum one the male Orpheus adorns and a giant heart-shaped lyre."
     },
     {
-      "name": "Archangel",
-      "evolvesTo": "Principality",
+      "name": "archangel",
+      "displayName": "Archangel",
+      "evolvesTo": "principality",
       "primaryElement": "Physical",
       "level": "5",
       "arcana": "Justice",
@@ -1754,7 +1785,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -5 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: -5 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Vajra Blast (4 HP, 2 actions)",
@@ -1766,14 +1797,15 @@
         },
         {
           "name": "Hama (6 SP, 1 action)",
-          "description": "Tapestries and minor sigils of holy exorcism attempt to snuff out a foe\u2019s will. Choose a creature within range and make a ranged attack against them (-5 to hit, 60 feet). On a hit, if the result of each d6 is 4 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Bless. This Skill provokes a \u000bOne More if the target is weak to Bless."
+          "description": "Tapestries and minor sigils of holy exorcism attempt to snuff out a foe\u2019s will. Choose a creature within range and make a ranged attack against them (-5 to hit, 60 feet). On a hit, if the result of each d6 is 4 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Bless. This Skill provokes a\nOne More if the target is weak to Bless."
         }
       ],
       "background": "The archangels are among the eighth sphere, making them second in the third hierarchy in the nine orders of angels in Christian teachings. Archangels are one of the few bodies of angels that contact those on the material plane directly and are the ministers and messengers between God and mankind. There is a dispute on whether famous archangels such as Michael and Gabriel are the same class as the \"plain\" archangels, who in the Kabbalah and in the Bible are called \"Beni Elohim\" (meaning \"children of God\"), or belong to a completely different order known as \"Rav-Malakhim\" or \"Malakhim-Panav,\" who are the angels that stand before the lord himself."
     },
     {
-      "name": "Eligor",
-      "evolvesTo": "Flauros",
+      "name": "eligor",
+      "displayName": "Eligor",
+      "evolvesTo": "flauros",
       "primaryElement": "Fire",
       "level": "5",
       "arcana": "Emperor",
@@ -1810,17 +1842,17 @@
       "traits": [
         {
           "name": "Thermal Conduct",
-          "description": "Conductive energies overheat a vulnerable foe. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with Burn (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "Conductive energies overheat a vulnerable foe. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with Burn (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -5 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: -5 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Agi (4 SP, 1 action)",
-          "description": "You fling a mote of flames at a target within range. Make a ranged attack against a creature within range \u000b(-5 to hit, 60 feet). On a hit, they receive 1d8 + 3 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
+          "description": "You fling a mote of flames at a target within range. Make a ranged attack against a creature within range\n(-5 to hit, 60 feet). On a hit, they receive 1d8 + 3 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
         },
         {
           "name": "Memory Blow (6 HP, 2 actions)",
@@ -1831,10 +1863,11 @@
           "description": "Invigorating force emboldens an ally. Choose a creature within range (90 feet). For 1 minute, whenever that creature rolls dice for a damage roll, they roll again, using whichever result is higher. You may target yourself with this Skill. If the creature is under the effects of Tarunda, instead that effect and the effect of this Skill are removed."
         }
       ],
-      "background": "Eligos, also known as Eligor or Abigor, is the 15th demonic spirit of Ars Goetia and a fallen angel. He governs over 60 legions of spirits. He is a great duke and appears in the form of a goodly knight carrying a lance, pennon (flag) and a scepter (a serpent to Aleister Crowley). Alternatively he is depicted as a ghostly specter, sometimes riding a semi-skeletal (sometimes winged) horse, or the Steed of Abigor. This is a minion of Hell itself, and was a gift from Beelzebub. It was created from the remains of one of the horses of the Garden of Eden.\n"
+      "background": "Eligos, also known as Eligor or Abigor, is the 15th demonic spirit of Ars Goetia and a fallen angel. He governs over 60 legions of spirits. He is a great duke and appears in the form of a goodly knight carrying a lance, pennon (flag) and a scepter (a serpent to Aleister Crowley). Alternatively he is depicted as a ghostly specter, sometimes riding a semi-skeletal (sometimes winged) horse, or the Steed of Abigor. This is a minion of Hell itself, and was a gift from Beelzebub. It was created from the remains of one of the horses of the Garden of Eden."
     },
     {
-      "name": "High Pixie",
+      "name": "high-pixie",
+      "displayName": "High Pixie",
       "evolvesTo": null,
       "primaryElement": "Healing",
       "level": "5",
@@ -1878,11 +1911,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 1d4 + 3 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 1d4 + 3 physical damage."
         },
         {
           "name": "Garu (3 SP, 1 action)",
-          "description": "A gust whips and strikes a foe, twisting them about. Make a ranged attack against a creature within range \u000b(-5 to hit, 60 feet). On a hit, they receive 1d8 + 3 wind damage."
+          "description": "A gust whips and strikes a foe, twisting them about. Make a ranged attack against a creature within range\n(-5 to hit, 60 feet). On a hit, they receive 1d8 + 3 wind damage."
         },
         {
           "name": "Media (9 SP, 2 actions)",
@@ -1893,11 +1926,12 @@
           "description": "Soft ripples froth below foe, attempting to sap their strength into exhaustion. Make a ranged attack against a creature within range (-5 to hit, 60 feet range). On a hit, if the result of each d6 is 2 or higher, the target is inflicted with Sleep (see \u201cConditions\u201d)."
         }
       ],
-      "background": "High Pixies are high ranking pixies that act as leaders or commanders of younger pixies. Generally, a charismatic pixie can obtain this rank from proving its skill and loyalty.\n They watch over the younger pixies as guardians, and ensure they are kept out of danger, although they are every bit as mischievous as their younger counterparts. They are charged with guarding the ruins and caves where other pixies dwell.\n"
+      "background": "High Pixies are high ranking pixies that act as leaders or commanders of younger pixies. Generally, a charismatic pixie can obtain this rank from proving its skill and loyalty.\n\nThey watch over the younger pixies as guardians, and ensure they are kept out of danger, although they are every bit as mischievous as their younger counterparts. They are charged with guarding the ruins and caves where other pixies dwell."
     },
     {
-      "name": "Inugami",
-      "evolvesTo": "Orthrus",
+      "name": "inugami",
+      "displayName": "Inugami",
+      "evolvesTo": "orthrus",
       "primaryElement": "Ailment",
       "level": "5",
       "arcana": "Hanged Man",
@@ -1934,13 +1968,13 @@
       "traits": [
         {
           "name": "Foul Stench",
-          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -5 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: -5 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Pulinpa (5 SP, 1 action)",
@@ -1955,10 +1989,11 @@
           "description": "With a circular and calculated blow, you follow up with a sundering slice. Make a melee attack against a creature within range (-5 to hit, 10 feet). On a hit, the creature receives 1d10 + Strength physical damage. If this Skill is used with an action granted by a Baton Pass, the damage dealt is doubled."
         }
       ],
-      "background": "In Japanese mythology, an inugami (\"dog god\") resembles, and usually originates from, a dog, (although other similar species are interpreted as being. e.g., wolves, raccoons, and weasels.) and most commonly carrying out vengeance or acting as guardians on behalf of their \"inugami owner.\" Inugami are extremely powerful and capable of existing independently, (without master or possession) as well as turning on their \"owners\" and even possessing humans. Even so, while Inugami can betray their masters, they may also be the loyalest of companions.\n"
+      "background": "In Japanese mythology, an inugami (\"dog god\") resembles, and usually originates from, a dog, (although other similar species are interpreted as being. e.g., wolves, raccoons, and weasels.) and most commonly carrying out vengeance or acting as guardians on behalf of their \"inugami owner.\" Inugami are extremely powerful and capable of existing independently, (without master or possession) as well as turning on their \"owners\" and even possessing humans. Even so, while Inugami can betray their masters, they may also be the loyalest of companions."
     },
     {
-      "name": "Kaguya",
+      "name": "kaguya",
+      "displayName": "Kaguya",
       "evolvesTo": null,
       "primaryElement": "Bless",
       "level": "5",
@@ -2003,7 +2038,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -5 to hit, range 5 ft., one target. \u000bHit: 1d6 + 2 physical damage."
+          "description": "Melee attack: -5 to hit, range 5 ft., one target.\nHit: 1d6 + 2 physical damage."
         },
         {
           "name": "Shining Arrows (10 SP, 2 actions)",
@@ -2018,10 +2053,11 @@
           "description": "You remedy the impurities of all your comrades, cleansing the field of malady. Choose up to six creatures within range (60 feet). Each of those creatures recover from all Conditions."
         }
       ],
-      "background": "Kaguya Hime is a character from a very famous Japanese folk story called Taketori Monogatari (\u7af9\u53d6\u7269\u8a9e), \"The Tale of the Bamboo Cutter.\" She was found by a Bamboo cutter inside a stalk of Bamboo. The cutter raised her as his own daughter and she became renowned throughout Japan for her beauty. Many men came to ask for her hand in marriage but she refused them all. Eventually the Emperor of Japan also heard of her beauty and desired to marry her. She refused him as well, however, he still continued to love her even though they never married.\n"
+      "background": "Kaguya Hime is a character from a very famous Japanese folk story called Taketori Monogatari (\u7af9\u53d6\u7269\u8a9e), \"The Tale of the Bamboo Cutter.\" She was found by a Bamboo cutter inside a stalk of Bamboo. The cutter raised her as his own daughter and she became renowned throughout Japan for her beauty. Many men came to ask for her hand in marriage but she refused them all. Eventually the Emperor of Japan also heard of her beauty and desired to marry her. She refused him as well, however, he still continued to love her even though they never married."
     },
     {
-      "name": "Makami",
+      "name": "makami",
+      "displayName": "Makami",
       "evolvesTo": null,
       "primaryElement": "Nuke",
       "level": "5",
@@ -2067,7 +2103,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -5 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: -5 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Frei (4 HP, 1 action)",
@@ -2075,17 +2111,18 @@
         },
         {
           "name": "Energy Drop (4 SP, 1 action)",
-          "description": "A stimulating remedy opens one\u2019s eyes against emotional malady. Choose a creature within range \u000b(60 feet). That creature recovers from Confuse, Fear, Despair, Rage, and Brainwash (see \u201cConditions\u201d)."
+          "description": "A stimulating remedy opens one\u2019s eyes against emotional malady. Choose a creature within range\n(60 feet). That creature recovers from Confuse, Fear, Despair, Rage, and Brainwash (see \u201cConditions\u201d)."
         },
         {
           "name": "Makajama (5 SP, 1 action)",
           "description": "A mote of void magic applied to the mind has disastrous results. Make a ranged attack against a creature within range (-5 to hit, 60 feet). On a hit, if the result of each d6 is 2 or higher, the target is inflicted with Forget."
         }
       ],
-      "background": "Makami, also written as Oguchi-no-Magami, is a divine beast in Japanese mythology. People originally feared the Makami, eventually that strong emotion deified the beast. The Makami can see into the hearts of humans, protecting those who are good but punishing those who are evil.\n It is often drawn on prayer boards used to ward evil, especially thefts and fire. But, there it is also feared as a human-eater. It is said that wolves became Makami.\n"
+      "background": "Makami, also written as Oguchi-no-Magami, is a divine beast in Japanese mythology. People originally feared the Makami, eventually that strong emotion deified the beast. The Makami can see into the hearts of humans, protecting those who are good but punishing those who are evil.\n\nIt is often drawn on prayer boards used to ward evil, especially thefts and fire. But, there it is also feared as a human-eater. It is said that wolves became Makami."
     },
     {
-      "name": "Shiisaa",
+      "name": "shiisaa",
+      "displayName": "Shiisaa",
       "evolvesTo": null,
       "primaryElement": "Nuke",
       "level": "5",
@@ -2130,7 +2167,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -5 to hit, range 5 ft., one target. \u000bHit: 1d6 + 2 physical damage."
+          "description": "Melee attack: -5 to hit, range 5 ft., one target.\nHit: 1d6 + 2 physical damage."
         },
         {
           "name": "Frei (4 HP, 1 action)",
@@ -2145,11 +2182,12 @@
           "description": "You unleash a rush of senseless attacks motivated from fury. Make three melee attacks against each creature within a 10-foot sphere centered at a point within range (-5 to hit, 10 feet). The first time an attack hits, each subsequent hit will use the same attack roll result as that first hit. For each hit, a creature receives 1d8 + 2 physical damage."
         }
       ],
-      "background": "Shisa is a Japanese protective spirit or guardian deity in Okinawan mythology. People place pairs of shisa on either their rooftops or flanking the gates to their houses, with the left shisa traditionally having a closed mouth and the right one an open mouth. The open mouth shisa wards off evil spirits while the closed mouth shisa keeps good spirits in.\n"
+      "background": "Shisa is a Japanese protective spirit or guardian deity in Okinawan mythology. People place pairs of shisa on either their rooftops or flanking the gates to their houses, with the left shisa traditionally having a closed mouth and the right one an open mouth. The open mouth shisa wards off evil spirits while the closed mouth shisa keeps good spirits in."
     },
     {
-      "name": "Black Ooze",
-      "evolvesTo": "Girimehkala",
+      "name": "black-ooze",
+      "displayName": "Black Ooze",
+      "evolvesTo": "girimehkala",
       "primaryElement": "Ailment",
       "level": "6",
       "arcana": "Moon",
@@ -2190,13 +2228,13 @@
       "traits": [
         {
           "name": "Foul Stench",
-          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -6 to hit, range 5 ft., one target. \u000bHit: 1d8 + 4 physical damage."
+          "description": "Melee attack: -6 to hit, range 5 ft., one target.\nHit: 1d8 + 4 physical damage."
         },
         {
           "name": "Evil Touch (5 SP, 1 action)",
@@ -2204,17 +2242,18 @@
         },
         {
           "name": "Brain Jack (10 SP, 2 actions)",
-          "description": "You\u2019re not asking anymore. You use magic to directly weave into the hearts of foes, seizing control of the field. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range \u000b(-4 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Brainwash (see \u201cConditions\u201d)."
+          "description": "You\u2019re not asking anymore. You use magic to directly weave into the hearts of foes, seizing control of the field. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range\n(-4 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Brainwash (see \u201cConditions\u201d)."
         },
         {
           "name": "Foul Breath (8 SP, 1 action)",
           "description": "A wretched stench of numerous unnamed diseases engulfs a foe. Choose a creature within range. For the next 10 minutes, whenever the creature would be potentially inflicted with a Condition, flip a coin. If heads, the Condition is successfully inflicted. This effect is in addition to the original means by which they are inflicted by the Condition."
         }
       ],
-      "background": "A slime, also commonly called ooze, are common types of monsters in many fantasy role-play games. True to their name, they don't usually have any distinct shape and appear as large masses of gelatinous fluid. Slimes and oozes vary between mediums, with some being intelligent and capable of assuming basic shapes with others being nothing more than brainless piles of goo that dissolve whatever matter becomes enveloped by their bodies.\n Like oozes, many slimes dwell underground, and most secrete an acid from their skin that dissolves flesh and other materials rapidly. In D&D, slimes are essentially blind, but more than make up for that with an ability called \"blindsight,\" which allows them to discern nearby objects and creatures without needing to see them visually."
+      "background": "A slime, also commonly called ooze, are common types of monsters in many fantasy role-play games. True to their name, they don't usually have any distinct shape and appear as large masses of gelatinous fluid. Slimes and oozes vary between mediums, with some being intelligent and capable of assuming basic shapes with others being nothing more than brainless piles of goo that dissolve whatever matter becomes enveloped by their bodies.\n\nLike oozes, many slimes dwell underground, and most secrete an acid from their skin that dissolves flesh and other materials rapidly. In D&D, slimes are essentially blind, but more than make up for that with an ability called \"blindsight,\" which allows them to discern nearby objects and creatures without needing to see them visually."
     },
     {
-      "name": "Leanan Sidhe",
+      "name": "leanan-sidhe",
+      "displayName": "Leanan Sidhe",
       "evolvesTo": null,
       "primaryElement": "Psychic",
       "level": "6",
@@ -2257,7 +2296,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Psio (8 SP, 1 action)",
@@ -2272,10 +2311,11 @@
           "description": "Baleful words and rusted nails puncture into the foe. Choose a creature within range and make a ranged attack against them (-4 to hit, 30 feet). On a hit, if the result of each d6 is 4 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Curse. This Skill provokes a One More if the target is weak to Curse."
         }
       ],
-      "background": "In Celtic folklore, the Irish leanan s\u00eddhe is a beautiful woman of the Aos S\u00ed (or fairy folk) who takes a human lover. Lovers of the Leanan S\u00eddhe are said to live brief, though highly inspired, lives. The Leanan S\u00eddhe is generally depicted as a beautiful muse, who offers inspiration to an artist in exchange for fame and glory; however, this exchange frequently results in madness for the artist, and often premature death.\n"
+      "background": "In Celtic folklore, the Irish leanan s\u00eddhe is a beautiful woman of the Aos S\u00ed (or fairy folk) who takes a human lover. Lovers of the Leanan S\u00eddhe are said to live brief, though highly inspired, lives. The Leanan S\u00eddhe is generally depicted as a beautiful muse, who offers inspiration to an artist in exchange for fame and glory; however, this exchange frequently results in madness for the artist, and often premature death."
     },
     {
-      "name": "Matador",
+      "name": "matador",
+      "displayName": "Matador",
       "evolvesTo": null,
       "primaryElement": "Psychic",
       "level": "6",
@@ -2317,7 +2357,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -4 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: -4 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Psi (4 SP, 1 action)",
@@ -2329,13 +2369,14 @@
         },
         {
           "name": "Swift Strike (8 HP, 2 actions)",
-          "description": "You deftly strike at each foe with blinding speed within an area. Make two melee attacks against each creature within a 20-foot sphere centered at a point within range (-4 to hit, 20 feet). For each hit, a creature receives \u000b1d8 + 3 physical damage."
+          "description": "You deftly strike at each foe with blinding speed within an area. Make two melee attacks against each creature within a 20-foot sphere centered at a point within range (-4 to hit, 20 feet). For each hit, a creature receives\n1d8 + 3 physical damage."
         }
       ],
-      "background": "Matador, lit. \"Bullfighter\" in European Spanish and Portuguese, is derived from the late Latin word mactator, which means to subdue or kill. It is also the name of the toreros (sometimes called \"toreadors\" in English-speaking territories due to the influence of Carmen) that perform in the bullfighting events famous in Spain. Matador is one of the toreros, and the word literally means \"killer,\" as it's the matador's job to kill the bull.\n"
+      "background": "Matador, lit. \"Bullfighter\" in European Spanish and Portuguese, is derived from the late Latin word mactator, which means to subdue or kill. It is also the name of the toreros (sometimes called \"toreadors\" in English-speaking territories due to the influence of Carmen) that perform in the bullfighting events famous in Spain. Matador is one of the toreros, and the word literally means \"killer,\" as it's the matador's job to kill the bull."
     },
     {
-      "name": "Nekomata",
+      "name": "nekomata",
+      "displayName": "Nekomata",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "6",
@@ -2371,13 +2412,13 @@
       "traits": [
         {
           "name": "Foul Stench",
-          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 1d4 + 4 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 1d4 + 4 physical damage."
         },
         {
           "name": "Evil Touch (5 SP, 1 action)",
@@ -2392,10 +2433,11 @@
           "description": "A wild barrage of palm strikes elicits light damage and an irate response. Make a melee attack against a creature within range (-4 to hit, 5 feet). On a hit, the creature receives 2d8 + 4 physical damage. If the result of each d6 in the attack roll is 4 or higher, the target is afflicted with Rage (see \u201cConditions\u201d)."
         }
       ],
-      "background": "In Japanese folklore, a nekomata, also known as a bakeneko, is a type of yokai that appears as a cat with supernatural abilities akin to those of the fox or raccoon dog. A cat may become a bakeneko in a number of ways: it may reach a certain age, be kept for a certain number of years, grow to a certain size or be allowed to keep a long tail. In the last case, the tail forks in two and the bakeneko is then called a nekomata. This superstition may have some connection to the breeding of the Japanese Bobtail.\n"
+      "background": "In Japanese folklore, a nekomata, also known as a bakeneko, is a type of yokai that appears as a cat with supernatural abilities akin to those of the fox or raccoon dog. A cat may become a bakeneko in a number of ways: it may reach a certain age, be kept for a certain number of years, grow to a certain size or be allowed to keep a long tail. In the last case, the tail forks in two and the bakeneko is then called a nekomata. This superstition may have some connection to the breeding of the Japanese Bobtail."
     },
     {
-      "name": "Orobas",
+      "name": "orobas",
+      "displayName": "Orobas",
       "evolvesTo": null,
       "primaryElement": "Fire",
       "level": "6",
@@ -2438,11 +2480,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 1d6 + 2 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 1d6 + 2 physical damage."
         },
         {
           "name": "Agi (4 SP, 1 action)",
-          "description": "You fling a mote of flames at a target within range. Make a ranged attack against a creature within range \u000b(+4 to hit, 60 feet). On a hit, they receive 1d8 + 3 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
+          "description": "You fling a mote of flames at a target within range. Make a ranged attack against a creature within range\n(+4 to hit, 60 feet). On a hit, they receive 1d8 + 3 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
         },
         {
           "name": "Marakunda (24 SP, 2 actions)",
@@ -2453,10 +2495,11 @@
           "description": "You erase all motes of strength for foes. Choose up to six creatures within range. All effects of Tarukaja, Rakukaja, Sukukaja are removed from them."
         }
       ],
-      "background": "According to the Lesser Key of Solomon, Orobas is the 55th demonic spirit and a powerful great prince of Hell who could give conjurers perfect information about the past, present or future, bestow honors, reconcile them with foes and protect them from being tempted by demons. He would never deceive anyone. He commands 20 legions of spirits (26 according to Harley 6483, considered the least reliable of the manuscripts). He supposedly also gives true answers of divinity and the creation of the world.\n"
+      "background": "According to the Lesser Key of Solomon, Orobas is the 55th demonic spirit and a powerful great prince of Hell who could give conjurers perfect information about the past, present or future, bestow honors, reconcile them with foes and protect them from being tempted by demons. He would never deceive anyone. He commands 20 legions of spirits (26 according to Harley 6483, considered the least reliable of the manuscripts). He supposedly also gives true answers of divinity and the creation of the world."
     },
     {
-      "name": "Shiki-Ouji",
+      "name": "shiki-ouji",
+      "displayName": "Shiki-Ouji",
       "evolvesTo": null,
       "primaryElement": "Gun",
       "level": "6",
@@ -2494,17 +2537,17 @@
       "traits": [
         {
           "name": "God Maker",
-          "description": "It is in your presence and by your hand that your allies are enabled to forge legends. You gain the following benefits:\n \u2022 Whenever an allied creature, excluding yourself, rolls dice as part of a Trait\u2019s effect (such as Counter, Gaia Pact, Mastery of Magic, etc), you may reroll the dice once. You must use the new result."
+          "description": "It is in your presence and by your hand that your allies are enabled to forge legends. You gain the following benefits:\n\u2022 Whenever an allied creature, excluding yourself, rolls dice as part of a Trait\u2019s effect (such as Counter, Gaia Pact, Mastery of Magic, etc), you may reroll the dice once. You must use the new result."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -4 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: -4 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Double Shot (6 HP, 1 action)",
-          "description": "Twin bolts of force or gunfire strike a target. Make two ranged attacks against a creature within range \u000b(-4 to hit, 30 feet). For each hit, the creature receives 1d10 + Strength gun damage."
+          "description": "Twin bolts of force or gunfire strike a target. Make two ranged attacks against a creature within range\n(-4 to hit, 30 feet). For each hit, the creature receives 1d10 + Strength gun damage."
         },
         {
           "name": "Tarukaja (8 SP, 1 action)",
@@ -2515,10 +2558,11 @@
           "description": "The arcane art of irritation is infused within your goading and jeering, evoking frustration from a foe. Make a ranged attack against a creature within range (-4 to hit, 60 feet). On a hit, if the result of each d6 is 2 or higher, the target is inflicted with Rage (see \u201cConditions\u201d)."
         }
       ],
-      "background": "The Shiki-Ouji (\u5f0f\u738b\u5b50*)? is an exceptionally powerful type of Shikigami that could only be summoned as a servant by the most elite of those that practiced the mystical arts of Yin and Yang. It could be used to scare away demons that cause sickness and to ward off disasters to its master. The Shikiouji's basic nature is said to be very close to that of an Oni and is thus very ferocious, making it very dangerous for average mystics to attempt to summon it.\n"
+      "background": "The Shiki-Ouji (\u5f0f\u738b\u5b50*)? is an exceptionally powerful type of Shikigami that could only be summoned as a servant by the most elite of those that practiced the mystical arts of Yin and Yang. It could be used to scare away demons that cause sickness and to ward off disasters to its master. The Shikiouji's basic nature is said to be very close to that of an Oni and is thus very ferocious, making it very dangerous for average mystics to attempt to summon it."
     },
     {
-      "name": "Sudama",
+      "name": "sudama",
+      "displayName": "Sudama",
       "evolvesTo": null,
       "primaryElement": "Psychic",
       "level": "6",
@@ -2555,13 +2599,13 @@
       "traits": [
         {
           "name": "Foul Stench",
-          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Psi (4 SP, 1 action)",
@@ -2569,18 +2613,19 @@
         },
         {
           "name": "Lucky Punch (2 HP, 1 action)",
-          "description": "You take a random swing, letting destiny do the work. Make a melee attack against a creature within range (-4 to hit, 10 feet). A creature hit by this attack receives \u000b1d10 + 1 physical damage. This Skill scores a Critical hit if the result of each d6 in its attack roll is 5 or higher."
+          "description": "You take a random swing, letting destiny do the work. Make a melee attack against a creature within range (-4 to hit, 10 feet). A creature hit by this attack receives\n1d10 + 1 physical damage. This Skill scores a Critical hit if the result of each d6 in its attack roll is 5 or higher."
         },
         {
           "name": "Tarukaja (8 SP, 1 action)",
           "description": "Invigorating force emboldens an ally. Choose a creature within range (90 feet). For 1 minute, whenever that creature rolls dice for a damage roll, they roll again, using whichever result is higher. You may target yourself with this Skill. If the creature is under the effects of Tarunda, instead that effect and the effect of this Skill are removed."
         }
       ],
-      "background": "Sudama, whose name means \"lurking souls\", are mischievous one footed spirits that roam the mountains, dwelling in large and ancient trees, rocks and rivers. Sudama are born from the pure essence of the rocks and trees of lush, green mountains where few humans have set foot.\n Sudama never causes trouble, and sometimes takes human shape in order to watch over their mountain homes. Tradition holds that when you are in the mountains and get the feeling you are being watched, it is a Sudama watching you.\n They are sometimes identified with the Kodama.\n"
+      "background": "Sudama, whose name means \"lurking souls\", are mischievous one footed spirits that roam the mountains, dwelling in large and ancient trees, rocks and rivers. Sudama are born from the pure essence of the rocks and trees of lush, green mountains where few humans have set foot.\n\nSudama never causes trouble, and sometimes takes human shape in order to watch over their mountain homes. Tradition holds that when you are in the mountains and get the feeling you are being watched, it is a Sudama watching you.\n\nThey are sometimes identified with the Kodama."
     },
     {
-      "name": "Suzaku",
-      "evolvesTo": "Seiryu",
+      "name": "suzaku",
+      "displayName": "Suzaku",
+      "evolvesTo": "seiryu",
       "primaryElement": "Nuke",
       "level": "6",
       "arcana": "Sun",
@@ -2617,13 +2662,13 @@
       "traits": [
         {
           "name": "Speed Master",
-          "description": "You have a unique sense for agile tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Sukukaja Skill at no cost or action."
+          "description": "You have a unique sense for agile tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Sukukaja Skill at no cost or action."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Frei (4 HP, 1 action)",
@@ -2631,18 +2676,19 @@
         },
         {
           "name": "Tarunda (8 SP, 1 action)",
-          "description": "You place a minor hex upon a foe, lessening their impact. Choose a creature within range \u000b(90 feet range). For 1 minute, whenever that creature rolls dice for a damage roll, they roll again, using whichever result is lower.  If the creature is under the effects of Tarukaja, instead that effect and the effect of this Skill are removed."
+          "description": "You place a minor hex upon a foe, lessening their impact. Choose a creature within range\n(90 feet range). For 1 minute, whenever that creature rolls dice for a damage roll, they roll again, using whichever result is lower.  If the creature is under the effects of Tarukaja, instead that effect and the effect of this Skill are removed."
         },
         {
           "name": "Dekunda (12 SP, 2 actions)",
           "description": "You cleanse impurities of the heart. Choose up to six creatures within range (90 feet). All effects of Tarunda, Rakunda, Sukunda are removed from them."
         }
       ],
-      "background": "The Zhu Que, also known as Vermilion Bird of the South or simply the Vermilion Bird, is one of the Four Symbols of the Chinese constellations (Si Xiang) along with Bai Hu, Xuan Wu and Qing Long. According to Wu Xing, the Taoist five-elemental system, it represents the fire element, the direction south and the season summer correspondingly. It is also known as Suzaku in Japan and Jujak in Korea. Suzaku is an elegant and noble bird in both appearance and behavior, it is very selective in what it eats and where it perches, with its feathers in many different hues of Vermilion.\n"
+      "background": "The Zhu Que, also known as Vermilion Bird of the South or simply the Vermilion Bird, is one of the Four Symbols of the Chinese constellations (Si Xiang) along with Bai Hu, Xuan Wu and Qing Long. According to Wu Xing, the Taoist five-elemental system, it represents the fire element, the direction south and the season summer correspondingly. It is also known as Suzaku in Japan and Jujak in Korea. Suzaku is an elegant and noble bird in both appearance and behavior, it is very selective in what it eats and where it perches, with its feathers in many different hues of Vermilion."
     },
     {
-      "name": "Flauros",
-      "evolvesTo": "Andras",
+      "name": "flauros",
+      "displayName": "Flauros",
+      "evolvesTo": "andras",
       "primaryElement": "Physical",
       "level": "7",
       "arcana": "Devil",
@@ -2686,7 +2732,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -4 to hit, range 5 ft., one target. \u000bHit: 1d6 + 4 physical damage."
+          "description": "Melee attack: -4 to hit, range 5 ft., one target.\nHit: 1d6 + 4 physical damage."
         },
         {
           "name": "Giant Slice (5 HP, 1 action)",
@@ -2701,10 +2747,11 @@
           "description": "You erase all motes of strength for foes. Choose up to six creatures within range. All effects of Tarukaja, Rakukaja, Sukukaja are removed from them."
         }
       ],
-      "background": "Flauros is the 64th demonic spirit of Ars Goetia. He is a great duke and appears at first as a mighty terrible and strong leopard but at the command of his summoner he assumes the shape of a man with fiery eyes and a terrible countenance.\n He can see the past and future, but unless he is commanded into a triangle he will lie in all those things. He will gladly talk of divinity and of the creation of the world, and of his and other spirits' falls from grace. He can control fire and burn all of his and his summoner's adversaries to death and will not suffer them to be tempted by any spirit or otherwise. He governs 36 legions of spirits.\n"
+      "background": "Flauros is the 64th demonic spirit of Ars Goetia. He is a great duke and appears at first as a mighty terrible and strong leopard but at the command of his summoner he assumes the shape of a man with fiery eyes and a terrible countenance.\n\nHe can see the past and future, but unless he is commanded into a triangle he will lie in all those things. He will gladly talk of divinity and of the creation of the world, and of his and other spirits' falls from grace. He can control fire and burn all of his and his summoner's adversaries to death and will not suffer them to be tempted by any spirit or otherwise. He governs 36 legions of spirits."
     },
     {
-      "name": "Izanagi",
+      "name": "izanagi",
+      "displayName": "Izanagi",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "7",
@@ -2742,32 +2789,33 @@
       "traits": [
         {
           "name": "God Maker",
-          "description": "It is in your presence and by your hand that your allies are enabled to forge legends. You gain the following benefits:\n \u2022 Whenever an allied creature, excluding yourself, rolls dice as part of a Trait\u2019s effect (such as Counter, Gaia Pact, Mastery of Magic, etc), you may reroll the dice once. You must use the new result."
+          "description": "It is in your presence and by your hand that your allies are enabled to forge legends. You gain the following benefits:\n\u2022 Whenever an allied creature, excluding yourself, rolls dice as part of a Trait\u2019s effect (such as Counter, Gaia Pact, Mastery of Magic, etc), you may reroll the dice once. You must use the new result."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -4 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: -4 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Cross Slash (10 HP, 2 actions)",
-          "description": "Two devastating slashes across the foe splits them into pieces perpendicularly. Make two melee attacks against a creature within range with advantage \u000b(-4 to hit, 10 feet). For each hit, the creature receives 3d8 + 3 physical damage."
+          "description": "Two devastating slashes across the foe splits them into pieces perpendicularly. Make two melee attacks against a creature within range with advantage\n(-4 to hit, 10 feet). For each hit, the creature receives 3d8 + 3 physical damage."
         },
         {
           "name": "Zionga (8 SP, 1 action)",
-          "description": "Streams of uncontrolled electricity rain upon a small area. Make a ranged attack against each creature within a 10-feet radius sphere centered at a point within range \u000b(-4 to hit, 30 feet). On a hit, they receive 1d8 + 2 electric damage. If each d6 in the attack roll is a 4 or higher, the target is also Shocked (see \u201cConditions\u201d)."
+          "description": "Streams of uncontrolled electricity rain upon a small area. Make a ranged attack against each creature within a 10-feet radius sphere centered at a point within range\n(-4 to hit, 30 feet). On a hit, they receive 1d8 + 2 electric damage. If each d6 in the attack roll is a 4 or higher, the target is also Shocked (see \u201cConditions\u201d)."
         },
         {
           "name": "Tarukaja (8 SP, 1 action)",
           "description": "Invigorating force emboldens an ally. Choose a creature within range (90 feet). For 1 minute, whenever that creature rolls dice for a damage roll, they roll again, using whichever result is higher. You may target yourself with this Skill. If the creature is under the effects of Tarunda, instead that effect and the effect of this Skill are removed."
         }
       ],
-      "background": "Izanagi (\u4f0a\u90aa\u90a3\u5c90, \u4f0a\u5f09\u8afe) is a Japanese creation deity born of the seven divine generations in Japanese mythology. He is also referred to in various chronicles such as the Kojiki and Nihon Shiki as Izanagi-no-Mikoto (\u4f0a\u90aa\u90a3\u5c90\u547d, \u4f0a\u5f09\u8afe\u5c0a), the \"male-who-invites.\"\n In marriage, he and Izanami have created many of the islands (all sans Onogoro Island) and deities of Japan. When Izanami died following the disastrous birth of Hi-no-Kagutsuchi, Izanagi slew the fire god out of grief stricken rage, then tried to retrieve her from the underworld, but failed. He mistakenly looks at her while she's in a rotting, monstrous state in the underworld, which shames her.\n"
+      "background": "Izanagi (\u4f0a\u90aa\u90a3\u5c90, \u4f0a\u5f09\u8afe) is a Japanese creation deity born of the seven divine generations in Japanese mythology. He is also referred to in various chronicles such as the Kojiki and Nihon Shiki as Izanagi-no-Mikoto (\u4f0a\u90aa\u90a3\u5c90\u547d, \u4f0a\u5f09\u8afe\u5c0a), the \"male-who-invites.\"\n\nIn marriage, he and Izanami have created many of the islands (all sans Onogoro Island) and deities of Japan. When Izanami died following the disastrous birth of Hi-no-Kagutsuchi, Izanagi slew the fire god out of grief stricken rage, then tried to retrieve her from the underworld, but failed. He mistakenly looks at her while she's in a rotting, monstrous state in the underworld, which shames her."
     },
     {
-      "name": "Jikokuten",
-      "evolvesTo": "Zouchouten",
+      "name": "jikokuten",
+      "displayName": "Jikokuten",
+      "evolvesTo": "zouchouten",
       "primaryElement": "Physical",
       "level": "7",
       "arcana": "Temperance",
@@ -2803,13 +2851,13 @@
       "traits": [
         {
           "name": "Defense Master",
-          "description": "You have a unique sense for defensive tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Rakukaja Skill at no cost or action."
+          "description": "You have a unique sense for defensive tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Rakukaja Skill at no cost or action."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Assault Dive (5 HP, 1 action)",
@@ -2824,10 +2872,11 @@
           "description": "A rallying cry and magic reinforcement strengthens your entire group. Choose up to six creatures within range (90 feet). Those creatures gain the effects of Tarukaja."
         }
       ],
-      "background": "Jikokuten (\u6301\u570b\u5929), or Dh\u1e5btar\u0101\u1e63\u1e6dra in Sanskrit, is a guardian deity with fierce expression that protects the east of Buddha's realm. He is associated with the color white. In China, he is regarded as being harmonious and compassionate, using his pipa to play music in order to convert others to Buddhism. In Japan, his statues mostly carry a sword. He is also the leader of the Gandharvas, the celestial musicians and messengers. His name means \"he who upholds the realm/nation.\"\n"
+      "background": "Jikokuten (\u6301\u570b\u5929), or Dh\u1e5btar\u0101\u1e63\u1e6dra in Sanskrit, is a guardian deity with fierce expression that protects the east of Buddha's realm. He is associated with the color white. In China, he is regarded as being harmonious and compassionate, using his pipa to play music in order to convert others to Buddhism. In Japan, his statues mostly carry a sword. He is also the leader of the Gandharvas, the celestial musicians and messengers. His name means \"he who upholds the realm/nation.\""
     },
     {
-      "name": "Nigi Mitama",
+      "name": "nigi-mitama",
+      "displayName": "Nigi Mitama",
       "evolvesTo": null,
       "primaryElement": "Healing",
       "level": "7",
@@ -2870,7 +2919,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +6 to hit, range 5 ft., one target. \u000bHit: 1d4 + 2 physical damage."
+          "description": "Melee attack: +6 to hit, range 5 ft., one target.\nHit: 1d4 + 2 physical damage."
         },
         {
           "name": "Baisudi (4 SP, 1 action)",
@@ -2882,14 +2931,15 @@
         },
         {
           "name": "Kouha (4 SP, 1 action)",
-          "description": "A wisp of light illuminates and strikes a target. Make a ranged attack against a creature within range \u000b(+4 to hit, 60 feet). On a hit, they receive 1d8 + 2 bless damage."
+          "description": "A wisp of light illuminates and strikes a target. Make a ranged attack against a creature within range\n(+4 to hit, 60 feet). On a hit, they receive 1d8 + 2 bless damage."
         }
       ],
-      "background": "In Japanese belief, Nigi Mitama is the calm and functional state of a person's soul, or kami, which is considered to be the opposite of Ara Mitama. The Ara Mitama must first be pacified with rites and worship before the Nigi Mitama will appear.\n"
+      "background": "In Japanese belief, Nigi Mitama is the calm and functional state of a person's soul, or kami, which is considered to be the opposite of Ara Mitama. The Ara Mitama must first be pacified with rites and worship before the Nigi Mitama will appear."
     },
     {
-      "name": "Nue",
-      "evolvesTo": "Bugs",
+      "name": "nue",
+      "displayName": "Nue",
+      "evolvesTo": "bugs",
       "primaryElement": "Curse",
       "level": "7",
       "arcana": "Death",
@@ -2932,11 +2982,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 1d8 + 3 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 1d8 + 3 physical damage."
         },
         {
           "name": "Eiha (4 SP, 1 action)",
-          "description": "Small tendrils of darkness slither from the earth and sting your target. Make a ranged attack against a creature within range (+4 to hit, 60 feet). On a hit, they receive \u000b3d8 + 2 curse damage."
+          "description": "Small tendrils of darkness slither from the earth and sting your target. Make a ranged attack against a creature within range (+4 to hit, 60 feet). On a hit, they receive\n3d8 + 2 curse damage."
         },
         {
           "name": "Skull Cracker (6 HP, 1 action)",
@@ -2947,10 +2997,11 @@
           "description": "Baleful words and rusted nails puncture into the foe. Choose a creature within range and make a ranged attack against them (+4 to hit, 30 feet). On a hit, if the result of each d6 is 4 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Curse. This Skill provokes a One More if the target is weak to Curse."
         }
       ],
-      "background": "A legendary monster in Japanese mythology. Nue has the head of a monkey, the arms and legs of a tiger, body of a raccoon dog and a snake for a tail.\n According to The Tale of the Heike, Emperor Konoe, the Emperor of Japan, became sick after having terrible nightmares every night, and a dark cloud appeared at two o'clock in the morning on the roof of the palace in Kyoto during the summer of 1153. The story says that the samurai Minamoto no Yorimasa staked-out the roof one night and fired an arrow into the cloud, out of which fell a dead Nue. Yorimasu then supposedly sank the body in the Sea of Japan.\n"
+      "background": "A legendary monster in Japanese mythology. Nue has the head of a monkey, the arms and legs of a tiger, body of a raccoon dog and a snake for a tail.\n\nAccording to The Tale of the Heike, Emperor Konoe, the Emperor of Japan, became sick after having terrible nightmares every night, and a dark cloud appeared at two o'clock in the morning on the roof of the palace in Kyoto during the summer of 1153. The story says that the samurai Minamoto no Yorimasa staked-out the roof one night and fired an arrow into the cloud, out of which fell a dead Nue. Yorimasu then supposedly sank the body in the Sea of Japan."
     },
     {
-      "name": "Oni",
+      "name": "oni",
+      "displayName": "Oni",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "7",
@@ -2985,13 +3036,13 @@
       "traits": [
         {
           "name": "Retaliating Body",
-          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n \u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n \u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled."
+          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n\u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n\u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 1d8 + 4 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 1d8 + 4 physical damage."
         },
         {
           "name": "Rampage (8 HP, 2 actions)",
@@ -2999,14 +3050,15 @@
         },
         {
           "name": "Snap (3 HP, 1 action)",
-          "description": "A pinpoint, puncturing strike penetrates the opponent\u2019s defenses. Make a ranged attack against a creature within range (+3 to hit, 15 feet). On a hit, the creature receives \u000b1d10 + 4 gun damage."
+          "description": "A pinpoint, puncturing strike penetrates the opponent\u2019s defenses. Make a ranged attack against a creature within range (+3 to hit, 15 feet). On a hit, the creature receives\n1d10 + 4 gun damage."
         }
       ],
-      "background": "Oni (\u9b3c) are creatures from Japanese folklore, variously translated as demons, devils, ogres or trolls. They are popular characters in Japanese art, literature and theater. Oni are known for attacking villages and plundering food, riches and women.\n"
+      "background": "Oni (\u9b3c) are creatures from Japanese folklore, variously translated as demons, devils, ogres or trolls. They are popular characters in Japanese art, literature and theater. Oni are known for attacking villages and plundering food, riches and women."
     },
     {
-      "name": "Orthrus",
-      "evolvesTo": "Cerberus",
+      "name": "orthrus",
+      "displayName": "Orthrus",
+      "evolvesTo": "cerberus",
       "primaryElement": "Fire",
       "level": "7",
       "arcana": "Hanged Man",
@@ -3043,13 +3095,13 @@
       "traits": [
         {
           "name": "Thermal Conduct",
-          "description": "Conductive energies overheat a vulnerable foe. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with Burn (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "Conductive energies overheat a vulnerable foe. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with Burn (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 1d8 + 3 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 1d8 + 3 physical damage."
         },
         {
           "name": "Agilao (8 SP, 1 action)",
@@ -3060,11 +3112,12 @@
           "description": "A rallying cry and magic reinforcement strengthens your entire group. Choose up to six creatures within range (90 feet). Those creatures gain the effects of Tarukaja."
         }
       ],
-      "background": "Orthrus was a two-headed dog and one of the many monsters sired by Typhon and Echidna from Greek mythology. Among his siblings were Cerberus, Sphinx and Chimera to name but a few. Orthrus was the dog of the Titan Geryon, and along with Eurytion, was the guardian of Geryon's herd of red cattle. Geryon, Eurytion and Orthrus were all slain when Heracles was completing the tenth of his twelve labors.\n"
+      "background": "Orthrus was a two-headed dog and one of the many monsters sired by Typhon and Echidna from Greek mythology. Among his siblings were Cerberus, Sphinx and Chimera to name but a few. Orthrus was the dog of the Titan Geryon, and along with Eurytion, was the guardian of Geryon's herd of red cattle. Geryon, Eurytion and Orthrus were all slain when Heracles was completing the tenth of his twelve labors."
     },
     {
-      "name": "Yaksini",
-      "evolvesTo": "Dakini",
+      "name": "yaksini",
+      "displayName": "Yaksini",
+      "evolvesTo": "dakini",
       "primaryElement": "Physical",
       "level": "7",
       "arcana": "Empress",
@@ -3101,13 +3154,13 @@
       "traits": [
         {
           "name": "Attack Master",
-          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action."
+          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Hysterical Slap (6 HP, 1 action)",
@@ -3122,11 +3175,12 @@
           "description": "A demonic dance swirls about and punctures foes in vital points. Make a melee attack against up to six creatures within range (+4 to hit, 20 feet). A creature hit by this attack receives 2d8 + 3 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Rage (see \u201cConditions\u201d)."
         }
       ],
-      "background": "A yaksini (Sanskrit: \u092f\u0915\u094d\u0937\u093f\u0923\u0940, yak\u1e63i\u1e47\u012b) is the female counterpart of the male yaksa, and they both attend to Kubera (also called Kuber), the Hindu god of wealth who rules in the mythical Himalayan kingdom of Alaka. Yaksini are often depicted as beautiful and voluptuous, with wide hips, narrow waists, broad shoulders and exaggerated, spherical breasts. In the Uddamareshvara Tantra, thirty-six yaksini are described, including their mantras and ritual prescriptions. A similar list of yaksas and yaksini is given in the Tantraraja Tantra, where it says that these beings are givers of whatever is desired.\n"
+      "background": "A yaksini (Sanskrit: \u092f\u0915\u094d\u0937\u093f\u0923\u0940, yak\u1e63i\u1e47\u012b) is the female counterpart of the male yaksa, and they both attend to Kubera (also called Kuber), the Hindu god of wealth who rules in the mythical Himalayan kingdom of Alaka. Yaksini are often depicted as beautiful and voluptuous, with wide hips, narrow waists, broad shoulders and exaggerated, spherical breasts. In the Uddamareshvara Tantra, thirty-six yaksini are described, including their mantras and ritual prescriptions. A similar list of yaksas and yaksini is given in the Tantraraja Tantra, where it says that these beings are givers of whatever is desired."
     },
     {
-      "name": "Anzu",
-      "evolvesTo": "Mitra",
+      "name": "anzu",
+      "displayName": "Anzu",
+      "evolvesTo": "mitra",
       "primaryElement": "Wind",
       "level": "8",
       "arcana": "Hierophant",
@@ -3170,7 +3224,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 1d6 + 2 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 1d6 + 2 physical damage."
         },
         {
           "name": "Garula (6 SP, 1 action)",
@@ -3185,10 +3239,11 @@
           "description": "You reach out your hand, and crush a foe\u2019s resilience to your attack. When you use this Skill, choose Fire, Ice, Electric, Wind, Psychic, or Nuke and up to six creatures within range (90 feet). For the next three rounds starting to count down at the end of this one, those creatures no longer Resist, Block, Drain, or Repel the chosen damage type. Additionally, this Skill removes all Tetrakarn and Makarakarn effects from affected creatures."
         }
       ],
-      "background": "Anzu, also known as Zu, Anzud or Imdugud, was a demonic tempest bird in Mesopotamian mythology.\n In his most famous mythical role, Anzu steals the Tablets of Destinies from Enlil, the lord of the wind. These objects gave the power to control fate to whoever possessed them, which in Mesopotamian mythology amounted to being able to control the universe.\n"
+      "background": "Anzu, also known as Zu, Anzud or Imdugud, was a demonic tempest bird in Mesopotamian mythology.\n\nIn his most famous mythical role, Anzu steals the Tablets of Destinies from Enlil, the lord of the wind. These objects gave the power to control fate to whoever possessed them, which in Mesopotamian mythology amounted to being able to control the universe."
     },
     {
-      "name": "Fuu-Ki",
+      "name": "fuu-ki",
+      "displayName": "Fuu-Ki",
       "evolvesTo": null,
       "primaryElement": "Wind",
       "level": "8",
@@ -3232,7 +3287,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +2 to hit, range 5 ft., one target. \u000bHit: 1d8 + 2 physical damage."
+          "description": "Melee attack: +2 to hit, range 5 ft., one target.\nHit: 1d8 + 2 physical damage."
         },
         {
           "name": "Garula (6 SP, 1 action)",
@@ -3247,10 +3302,11 @@
           "description": "Invigorating force emboldens an ally. Choose a creature within range (90 feet). For 1 minute, whenever that creature rolls dice for a damage roll, they roll again, using whichever result is higher. You may target yourself with this Skill. If the creature is under the effects of Tarunda, instead that effect and the effect of this Skill are removed."
         }
       ],
-      "background": "Fuu-Ki (\u98a8\u9b3c) whose name means \"Wind Oni\" is one of the four oni that was summoned by Fujiwara-No-Chikata (\u85e4\u539f\u5343\u65b9) during the mid-Heian period. Fuu-Ki can harness powerful winds which it uses to blow away enemies.\n"
+      "background": "Fuu-Ki (\u98a8\u9b3c) whose name means \"Wind Oni\" is one of the four oni that was summoned by Fujiwara-No-Chikata (\u85e4\u539f\u5343\u65b9) during the mid-Heian period. Fuu-Ki can harness powerful winds which it uses to blow away enemies."
     },
     {
-      "name": "Kin-Ki",
+      "name": "kin-ki",
+      "displayName": "Kin-Ki",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "8",
@@ -3286,13 +3342,13 @@
       "traits": [
         {
           "name": "Retaliating Body",
-          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n \u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n \u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled."
+          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n\u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n\u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 1d8 + 2 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 1d8 + 2 physical damage."
         },
         {
           "name": "Bad Beat (12 HP, 2 actions)",
@@ -3307,11 +3363,12 @@
           "description": "You begin amassing your strength and stamina, coalescing into an ultimate strike. The next damage roll you make for an attack that deals Physical or Gun damage within the next 10 minutes is doubled."
         }
       ],
-      "background": "Kin-Ki (\u91d1\u9b3c) whose name means \"Gold Oni\" is one of the four oni controlled by Fujiwara No Chikata (\u85e4\u539f\u5343\u65b9) during the mid-Heian period of Japan. Kin-Ki's body is so strong that no physical weapons in existence can pierce it.\n"
+      "background": "Kin-Ki (\u91d1\u9b3c) whose name means \"Gold Oni\" is one of the four oni controlled by Fujiwara No Chikata (\u85e4\u539f\u5343\u65b9) during the mid-Heian period of Japan. Kin-Ki's body is so strong that no physical weapons in existence can pierce it."
     },
     {
-      "name": "Naga",
-      "evolvesTo": "Ananta",
+      "name": "naga",
+      "displayName": "Naga",
+      "evolvesTo": "ananta",
       "primaryElement": "Electric",
       "level": "8",
       "arcana": "Hermit",
@@ -3354,26 +3411,27 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +6 to hit, range 5 ft., one target. \u000bHit: 1d4 + 2 physical damage."
+          "description": "Melee attack: +6 to hit, range 5 ft., one target.\nHit: 1d4 + 2 physical damage."
         },
         {
           "name": "Zionga (8 SP, 1 action)",
-          "description": "Streams of uncontrolled electricity rain upon a small area. Make a ranged attack against each creature within a 10-feet radius sphere centered at a point within range \u000b(+4 to hit, 30 feet). On a hit, they receive 1d8 + 2 electric damage. If each d6 in the attack roll is a 4 or higher, the target is also Shocked (see \u201cConditions\u201d)."
+          "description": "Streams of uncontrolled electricity rain upon a small area. Make a ranged attack against each creature within a 10-feet radius sphere centered at a point within range\n(+4 to hit, 30 feet). On a hit, they receive 1d8 + 2 electric damage. If each d6 in the attack roll is a 4 or higher, the target is also Shocked (see \u201cConditions\u201d)."
         },
         {
           "name": "Power Slash (5 HP, 1 action)",
-          "description": "A powerful stroke with a trained arm causes immense injury. Make a melee attack against a creature within range (+4 to hit, 5 feet). On a hit, the creature receives \u000b2d10 + 1d8 + 3 physical damage."
+          "description": "A powerful stroke with a trained arm causes immense injury. Make a melee attack against a creature within range (+4 to hit, 5 feet). On a hit, the creature receives\n2d10 + 1d8 + 3 physical damage."
         },
         {
           "name": "Memory Blow (6 HP, 2 actions)",
           "description": "You focus your inner strength, and unleash it as a thunderous burst from yourself. Make a melee attack against each creature within a 20-foot sphere centered at a point within range (+4 to hit, 20 feet). A creature hit by this attack receives 2d8 + 2 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Forget (see \u201cConditions\u201d)."
         }
       ],
-      "background": "The naga are divine, semi-divine deities or a semi-divine race of half-human half-serpent beings that reside in the underworld (Patala) and can occasionally take human form. They are principally depicted in three forms: wholly human with snakes on the heads and necks, common serpents or as half-human half-snake beings. A female naga is a \"nagi,\" \"nagin\" or \"nagini,\" and are said to be both beautiful and clever. Nagaraja is seen as the king of nagas. They are common and hold cultural significance in the mythological traditions of many South Asian and Southeast Asian cultures.\n"
+      "background": "The naga are divine, semi-divine deities or a semi-divine race of half-human half-serpent beings that reside in the underworld (Patala) and can occasionally take human form. They are principally depicted in three forms: wholly human with snakes on the heads and necks, common serpents or as half-human half-snake beings. A female naga is a \"nagi,\" \"nagin\" or \"nagini,\" and are said to be both beautiful and clever. Nagaraja is seen as the king of nagas. They are common and hold cultural significance in the mythological traditions of many South Asian and Southeast Asian cultures."
     },
     {
-      "name": "Rakshasa",
-      "evolvesTo": "Asura",
+      "name": "rakshasa",
+      "displayName": "Rakshasa",
+      "evolvesTo": "asura",
       "primaryElement": "Physical",
       "level": "8",
       "arcana": "Strength",
@@ -3412,13 +3470,13 @@
       "traits": [
         {
           "name": "Retaliating Body",
-          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n \u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n \u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled"
+          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n\u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n\u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled"
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 1d8 + 4 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 1d8 + 4 physical damage."
         },
         {
           "name": "Giant Slice (5 HP, 1 action)",
@@ -3433,10 +3491,11 @@
           "description": "A cruel cleave sunders mind and body. Make a melee attack against each creature within a 20-foot sphere centered at a point within range (+3 to hit, 20 feet). A creature hit by this attack receives 2d8 + 4 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Confuse (see \u201cConditions'')."
         }
       ],
-      "background": "A rakshasa is a demon or unrighteous spirit in Hindu and Buddhist mythology. Rakshasas are also called cannibals.\n According to the Ramayana, rakshasas were created from Brahma's foot; other sources claim they are descended from Pulastya, or from Khasa, or from Nirrti and Nirrita. Ravana is said to be the king of rakshasas.\n"
+      "background": "A rakshasa is a demon or unrighteous spirit in Hindu and Buddhist mythology. Rakshasas are also called cannibals.\n\nAccording to the Ramayana, rakshasas were created from Brahma's foot; other sources claim they are descended from Pulastya, or from Khasa, or from Nirrti and Nirrita. Ravana is said to be the king of rakshasas."
     },
     {
-      "name": "Sandman",
+      "name": "sandman",
+      "displayName": "Sandman",
       "evolvesTo": null,
       "primaryElement": "Ailment",
       "level": "8",
@@ -3474,13 +3533,13 @@
       "traits": [
         {
           "name": "Ghost Nest",
-          "description": "Ethereal claws of your will aid in penetrating the defenses of others. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with a Condition, roll 1d4. On a 4, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "Ethereal claws of your will aid in penetrating the defenses of others. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with a Condition, roll 1d4. On a 4, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +7 to hit, range 5 ft., one target. \u000bHit: 1d4 + 2 physical damage."
+          "description": "Melee attack: +7 to hit, range 5 ft., one target.\nHit: 1d4 + 2 physical damage."
         },
         {
           "name": "Dormina (5 SP, 1 action)",
@@ -3492,13 +3551,14 @@
         },
         {
           "name": "Dormin Rush (12 HP, 2 actions)",
-          "description": "A devastating blow to an area of heads knocks many unconscious. Make a melee attack against each creature within a 20-foot sphere centered at a point within range \u000b(+5 to hit, 20 feet). A creature hit by this attack receives \u000b2d8 + 2 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Sleep (see \u201cConditions\u201d)."
+          "description": "A devastating blow to an area of heads knocks many unconscious. Make a melee attack against each creature within a 20-foot sphere centered at a point within range\n(+5 to hit, 20 feet). A creature hit by this attack receives\n2d8 + 2 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Sleep (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Originating from Northern European lore (specifically rural Germany), the Sandman is a faerie that is rumored to put people to sleep by sprinkling magical sand onto the eyes of children while they sleep at night. The rheum in one's eyes upon waking is believed to be the result of the Sandman's work the previous evening.\n If a victim resisted, he would sit on their eyelids to force them to sleep. For bad children who still wouldn't sleep, he would scoop their eyes out.\n"
+      "background": "Originating from Northern European lore (specifically rural Germany), the Sandman is a faerie that is rumored to put people to sleep by sprinkling magical sand onto the eyes of children while they sleep at night. The rheum in one's eyes upon waking is believed to be the result of the Sandman's work the previous evening.\n\nIf a victim resisted, he would sit on their eyelids to force them to sleep. For bad children who still wouldn't sleep, he would scoop their eyes out."
     },
     {
-      "name": "Sui-Ki",
+      "name": "sui-ki",
+      "displayName": "Sui-Ki",
       "evolvesTo": null,
       "primaryElement": "Ice",
       "level": "8",
@@ -3543,7 +3603,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 1d6 + 2 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 1d6 + 2 physical damage."
         },
         {
           "name": "Bufula (8 SP, 1 action)",
@@ -3558,11 +3618,12 @@
           "description": "A magical decree of war creates a tension, a pressure to enter a frenzy  within the battlefield. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range (+4 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Rage (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Sui-Ki (\u6c34\u9b3c) whose name means \"Water Oni\" is of the four oni controlled by Fujiwara-no-Chikata (\u85e4\u539f\u5343\u65b9) during the mid-Heian period. Sui-ki can freeze anything to the core.\n"
+      "background": "Sui-Ki (\u6c34\u9b3c) whose name means \"Water Oni\" is of the four oni controlled by Fujiwara-no-Chikata (\u85e4\u539f\u5343\u65b9) during the mid-Heian period. Sui-ki can freeze anything to the core."
     },
     {
-      "name": "Andras",
-      "evolvesTo": "Decarabia",
+      "name": "andras",
+      "displayName": "Andras",
+      "evolvesTo": "decarabia",
       "primaryElement": "Ailment",
       "level": "9",
       "arcana": "Devil",
@@ -3601,13 +3662,13 @@
       "traits": [
         {
           "name": "Foul Stench",
-          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage"
+          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage"
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 1d6 + 2 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 1d6 + 2 physical damage."
         },
         {
           "name": "Evil Touch (5 SP, 1 action)",
@@ -3622,11 +3683,12 @@
           "description": "Dark energy pours from your mouth, manifesting in a banshee\u2019s cry that severs the souls of the weak-willed. This Skill affects all creatures within range, including yourself and allies. Each creature afflicted by the Fear condition (see \u201cConditions\u201d) within range is reduced to 0 hit points immediately."
         }
       ],
-      "background": "According to the writings in The Lesser Key of Solomon, Andras is the sixty-third demonic spirit listed in Ars Goetia. Among the spirits of the Goetia, Andras is one of the most violent and dangerous to summon. The conjurer and any attendants he may have must stay within a magic circle at all times no matter how much Andras tempts them to leave it, or he will surely kill them. He is able to control a person's anger or inflict rage upon any person the conjurer desires and tempt people to kill their servants or masters. If so asked, Andras will gladly kill any person the conjurer desires, and in certain demonology it is suggested that Flauros is his servant.\n"
+      "background": "According to the writings in The Lesser Key of Solomon, Andras is the sixty-third demonic spirit listed in Ars Goetia. Among the spirits of the Goetia, Andras is one of the most violent and dangerous to summon. The conjurer and any attendants he may have must stay within a magic circle at all times no matter how much Andras tempts them to leave it, or he will surely kill them. He is able to control a person's anger or inflict rage upon any person the conjurer desires and tempt people to kill their servants or masters. If so asked, Andras will gladly kill any person the conjurer desires, and in certain demonology it is suggested that Flauros is his servant."
     },
     {
-      "name": "Choronzon",
-      "evolvesTo": "Legion",
+      "name": "choronzon",
+      "displayName": "Choronzon",
+      "evolvesTo": "legion",
       "primaryElement": "Curse",
       "level": "9",
       "arcana": "Magician",
@@ -3669,11 +3731,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 1d8 + 2 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 1d8 + 2 physical damage."
         },
         {
           "name": "Life Drain (5 SP, 1 action)",
-          "description": "You reach out, savoring life force from a foe. Make a ranged attack against a creature within range \u000b(+3 to hit, 30 feet). On a hit, the creature receives 7 almighty damage, and you regain 7 hit points."
+          "description": "You reach out, savoring life force from a foe. Make a ranged attack against a creature within range\n(+3 to hit, 30 feet). On a hit, the creature receives 7 almighty damage, and you regain 7 hit points."
         },
         {
           "name": "Eiga (8 SP, 1 action)",
@@ -3684,11 +3746,12 @@
           "description": "You unleash a rush of senseless attacks motivated from fury. Make three melee attacks against each creature within a 10-foot sphere centered at a point within range (+3 to hit, 10 feet). The first time an attack hits, each subsequent hit will use the same attack roll result as that first hit. For each hit, a creature receives 1d8 + 2 physical damage"
         }
       ],
-      "background": "Choronzon, known as the Dweller in the Abyss or the Demon of Dispersion, is a demon known to hold vast amounts of knowledge that was summoned by Aleister Crowley. Crowley was supposedly attempting to gain wisdom from the 11th order of demons. However, the summoned Choronzon inflicted severe suffering on Crowley's disciples. Crowley was later said to either succeed in gaining wisdom, or was possessed instead. It is the last hurdle in conquering the dark side of the ego.\n"
+      "background": "Choronzon, known as the Dweller in the Abyss or the Demon of Dispersion, is a demon known to hold vast amounts of knowledge that was summoned by Aleister Crowley. Crowley was supposedly attempting to gain wisdom from the 11th order of demons. However, the summoned Choronzon inflicted severe suffering on Crowley's disciples. Crowley was later said to either succeed in gaining wisdom, or was possessed instead. It is the last hurdle in conquering the dark side of the ego."
     },
     {
-      "name": "Clotho",
-      "evolvesTo": "Lachesis",
+      "name": "clotho",
+      "displayName": "Clotho",
+      "evolvesTo": "lachesis",
       "primaryElement": "Bless",
       "level": "9",
       "arcana": "Fortune",
@@ -3730,7 +3793,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +7 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: +7 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Hamaon (12 SP, 1 action)",
@@ -3745,11 +3808,12 @@
           "description": "A psionic abyss springs forth from your fingertips, draining the memories of a field of foes. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range (+5 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Forget (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Clotho is the youngest of the three Moirae Sisters, and is derived from the Greek personification of fate. Clotho spins the thread of life. Clotho was responsible for spinning the thread of human life. She also made major decisions, such as when a person was born, thus in effect controlling people's lives. This power enabled her not only to choose who was born, but also to decide when gods or mortals were to be saved or put to death.\n"
+      "background": "Clotho is the youngest of the three Moirae Sisters, and is derived from the Greek personification of fate. Clotho spins the thread of life. Clotho was responsible for spinning the thread of human life. She also made major decisions, such as when a person was born, thus in effect controlling people's lives. This power enabled her not only to choose who was born, but also to decide when gods or mortals were to be saved or put to death."
     },
     {
-      "name": "Isis",
-      "evolvesTo": "Anubis",
+      "name": "isis",
+      "displayName": "Isis",
+      "evolvesTo": "anubis",
       "primaryElement": "Bless",
       "level": "9",
       "arcana": "Priestess",
@@ -3790,26 +3854,27 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +6 to hit, range 5 ft., one target. \u000bHit: 1d4 + 2 physical damage."
+          "description": "Melee attack: +6 to hit, range 5 ft., one target.\nHit: 1d4 + 2 physical damage."
         },
         {
           "name": "Kouga (8 SP, 1 action)",
-          "description": "Twin blades of pure light manifest, puncturing the foe on each side. Make a ranged attack against a creature within range (+4 to hit, 60 feet). On a hit, they receive \u000b2d8 + 4 bless damage."
+          "description": "Twin blades of pure light manifest, puncturing the foe on each side. Make a ranged attack against a creature within range (+4 to hit, 60 feet). On a hit, they receive\n2d8 + 4 bless damage."
         },
         {
           "name": "Hamaon (12 SP, 1 action)",
-          "description": "Divine will and an excess of banishing rights and rituals consecrate the creature\u2019s space, purging it of evil and existence. Choose a creature within range and make a ranged attack against them (+4 to hit, 90 feet). On a hit, if the result of each d6 is 3 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Bless. This Skill provokes a \u000bOne More if the target is weak to Bless."
+          "description": "Divine will and an excess of banishing rights and rituals consecrate the creature\u2019s space, purging it of evil and existence. Choose a creature within range and make a ranged attack against them (+4 to hit, 90 feet). On a hit, if the result of each d6 is 3 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Bless. This Skill provokes a\nOne More if the target is weak to Bless."
         },
         {
           "name": "Diarama (9 SP, 1 action)",
           "description": "Spiraling angelic light envelops an ally to rejuvenate them. Choose a creature within range (90 feet). That creature regains 3d8 + Magic hit points."
         }
       ],
-      "background": "Isis, also known as Aset or Eset, was a mother goddess in ancient Egyptian religious beliefs, whose worship spread throughout the Greco-Roman world. She was worshiped as the ideal mother and wife, patron of nature and magic; friend of slaves, sinners, artisans and the downtrodden, as well as listening to the prayers of the wealthy, maidens, aristocrats and rulers.\n"
+      "background": "Isis, also known as Aset or Eset, was a mother goddess in ancient Egyptian religious beliefs, whose worship spread throughout the Greco-Roman world. She was worshiped as the ideal mother and wife, patron of nature and magic; friend of slaves, sinners, artisans and the downtrodden, as well as listening to the prayers of the wealthy, maidens, aristocrats and rulers."
     },
     {
-      "name": "Lamia",
-      "evolvesTo": "Ananta",
+      "name": "lamia",
+      "displayName": "Lamia",
+      "evolvesTo": "ananta",
       "primaryElement": "Fire",
       "level": "9",
       "arcana": "Empress",
@@ -3847,13 +3912,13 @@
       "traits": [
         {
           "name": "Foul Stench",
-          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage"
+          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage"
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 1d4 + 4 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 1d4 + 4 physical damage."
         },
         {
           "name": "Agilao (8 SP, 1 action)",
@@ -3868,11 +3933,12 @@
           "description": "You whisper terrible, forbidden knowledge that plunges a foe closer to madness. Make a ranged attack against a creature within range (+3 to hit, 60 feet). On a hit, if the result of each d6 is 2 or higher, the target is inflicted with Despair (see \u201cConditions\u201d)."
         }
       ],
-      "background": "According to Greek mythology, Lamia was a Libyan queen who fell in love with Zeus and bore him children. Hera became enraged and murdered all of Lamia's children (one version of the tale claims that Hera forced Lamia to kill and eat her own children). Lamia went insane with grief and began kidnapping and eating children, eventually turning into a hideous monster as a result. Legend states that Zeus granted Lamia the ability to remove her own eyes at will so she would not see her dead children when she closed her eyes. In some sources, Lamia became a Naga.\n"
+      "background": "According to Greek mythology, Lamia was a Libyan queen who fell in love with Zeus and bore him children. Hera became enraged and murdered all of Lamia's children (one version of the tale claims that Hera forced Lamia to kill and eat her own children). Lamia went insane with grief and began kidnapping and eating children, eventually turning into a hideous monster as a result. Legend states that Zeus granted Lamia the ability to remove her own eyes at will so she would not see her dead children when she closed her eyes. In some sources, Lamia became a Naga."
     },
     {
-      "name": "Orpheus",
-      "evolvesTo": "Thanatos",
+      "name": "orpheus",
+      "displayName": "Orpheus",
+      "evolvesTo": "thanatos",
       "primaryElement": "Healing",
       "level": "9",
       "arcana": "Fool",
@@ -3914,7 +3980,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 1d8 + 2 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 1d8 + 2 physical damage."
         },
         {
           "name": "Cadenza (32 SP, 2 actions)",
@@ -3929,11 +3995,12 @@
           "description": "You coordinate the defense of your allies, covering flanks and shielding them from danger. Choose up to six creatures within range. Those creatures gain the effects of Rakukaja."
         }
       ],
-      "background": "In Greek mythology, Orpheus was the son of Thracian king Oeagrus and the muse Calliope (some versions have Orpheus' father as the god Apollo). Apollo, fond of Orpheus, gave him a small golden lyre, which he quickly mastered. Taught to sing verses by his mother, Orpheus was so skilled at making music that he was called \"Master of Strings\" and \"Father of Songs,\" capable of such music that even rocks and animals would be compelled to dance.\n"
+      "background": "In Greek mythology, Orpheus was the son of Thracian king Oeagrus and the muse Calliope (some versions have Orpheus' father as the god Apollo). Apollo, fond of Orpheus, gave him a small golden lyre, which he quickly mastered. Taught to sing verses by his mother, Orpheus was so skilled at making music that he was called \"Master of Strings\" and \"Father of Songs,\" capable of such music that even rocks and animals would be compelled to dance."
     },
     {
-      "name": "Pisaca",
-      "evolvesTo": "Arahabaki",
+      "name": "pisaca",
+      "displayName": "Pisaca",
+      "evolvesTo": "arahabaki",
       "primaryElement": "Ailment",
       "level": "9",
       "arcana": "Death",
@@ -3977,7 +4044,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 1d6 + 2 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 1d6 + 2 physical damage."
         },
         {
           "name": "Mudoon (12 SP, 1 action)",
@@ -3992,10 +4059,11 @@
           "description": "You blanket the minds and bodies of a battlefield in hopelessness and magic devoid of reason. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range (+4 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Despair (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Pisacas are demonic creatures that feast on human meat, especially corpses. They are mentioned to be on the same level as other abominations, such as Rakshasa, and are considered to be the physical incarnation of ignus fatuus. The origin of their names is believed to have been a result of the demonization of Hindu tribes by Aryan people.\n"
+      "background": "Pisacas are demonic creatures that feast on human meat, especially corpses. They are mentioned to be on the same level as other abominations, such as Rakshasa, and are considered to be the physical incarnation of ignus fatuus. The origin of their names is believed to have been a result of the demonization of Hindu tribes by Aryan people."
     },
     {
-      "name": "Setanta",
+      "name": "setanta",
+      "displayName": "Setanta",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "9",
@@ -4032,13 +4100,13 @@
       "traits": [
         {
           "name": "Retaliating Body",
-          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n \u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n \u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled"
+          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n\u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n\u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled"
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 1d6 + 2 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 1d6 + 2 physical damage."
         },
         {
           "name": "Rising Slash (9 HP, 1 action)",
@@ -4053,10 +4121,11 @@
           "description": "Golden light of obstinance heightens an ally\u2019s ability to deliver punishment. Choose a creature within range (90 feet). For 1 minute, attacks the creature makes score a Critical hit if the result of each d6 is a 5 or higher."
         }
       ],
-      "background": "Setanta is Cu Chulainn's given name. He obtained his more well-known alias when he killed Culann's guard dog in self-defense and volunteered to take its place (\"Cu Chulainn\" means \"Culann's Hound\").\n"
+      "background": "Setanta is Cu Chulainn's given name. He obtained his more well-known alias when he killed Culann's guard dog in self-defense and volunteered to take its place (\"Cu Chulainn\" means \"Culann's Hound\")."
     },
     {
-      "name": "Take-Minakata",
+      "name": "take-minakata",
+      "displayName": "Take-Minakata",
       "evolvesTo": null,
       "primaryElement": "Electric",
       "level": "9",
@@ -4093,17 +4162,17 @@
       "traits": [
         {
           "name": "Defense Master",
-          "description": "You have a unique sense for defensive tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Rakukaja Skill at no cost or action."
+          "description": "You have a unique sense for defensive tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Rakukaja Skill at no cost or action."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 1d8 + 2 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 1d8 + 2 physical damage."
         },
         {
           "name": "Zionga (8 SP, 1 action)",
-          "description": "Streams of uncontrolled electricity rain upon a small area. Make a ranged attack against each creature within a 10-feet radius sphere centered at a point within range \u000b(+3 to hit, 30 feet). On a hit, they receive 1d8 + 3 electric damage. If each d6 in the attack roll is a 4 or higher, the target is also Shocked (see \u201cConditions\u201d)."
+          "description": "Streams of uncontrolled electricity rain upon a small area. Make a ranged attack against each creature within a 10-feet radius sphere centered at a point within range\n(+3 to hit, 30 feet). On a hit, they receive 1d8 + 3 electric damage. If each d6 in the attack roll is a 4 or higher, the target is also Shocked (see \u201cConditions\u201d)."
         },
         {
           "name": "Assault Dive (5 HP, 1 action)",
@@ -4111,14 +4180,15 @@
         },
         {
           "name": "Swift Strike (8 HP, 2 actions)",
-          "description": "You deftly strike at each foe with blinding speed within an area. Make two melee attacks against each creature within a 20-foot sphere centered at a point within range (+3 to hit, 20 feet). For each hit, a creature receives \u000b1d8 + 2 physical damage."
+          "description": "You deftly strike at each foe with blinding speed within an area. Make two melee attacks against each creature within a 20-foot sphere centered at a point within range (+3 to hit, 20 feet). For each hit, a creature receives\n1d8 + 2 physical damage."
         }
       ],
-      "background": "Take-Minakata-no-kami (kanji: \u5efa\u5fa1\u540d\u65b9\u795e), is one of the sons of Okuninushi. When the Amatsu decided to increase their influence on the earth, they sent Take-Mikazuchi to conquer Take-Minakata. They had the first sumo match which Take-Mikazuchi won. Take-Minakata then had his arms cut and fled to Suwa, where he married a Suwa goddess, Yasakatome, and became the guardian god. The local legend believed the cracking phenomenon on the icy Lake Suwa in every winter to be the \"Passage of God\" (\u5fa1\u795e\u6e21\u308a, Omiwatari, scientifically the result of pressure ridge). Take-Minakata leaves his temple via the frozen lake to the opposite bank to meet the goddess.\n"
+      "background": "Take-Minakata-no-kami (kanji: \u5efa\u5fa1\u540d\u65b9\u795e), is one of the sons of Okuninushi. When the Amatsu decided to increase their influence on the earth, they sent Take-Mikazuchi to conquer Take-Minakata. They had the first sumo match which Take-Mikazuchi won. Take-Minakata then had his arms cut and fled to Suwa, where he married a Suwa goddess, Yasakatome, and became the guardian god. The local legend believed the cracking phenomenon on the icy Lake Suwa in every winter to be the \"Passage of God\" (\u5fa1\u795e\u6e21\u308a, Omiwatari, scientifically the result of pressure ridge). Take-Minakata leaves his temple via the frozen lake to the opposite bank to meet the goddess."
     },
     {
-      "name": "Tam Lin",
-      "evolvesTo": "Oberon",
+      "name": "tam-lin",
+      "displayName": "Tam Lin",
+      "evolvesTo": "oberon",
       "primaryElement": "Physical",
       "level": "9",
       "arcana": "Faith",
@@ -4156,13 +4226,13 @@
       "traits": [
         {
           "name": "Sharp Student",
-          "description": "Your skill and cunning allows you to avoid the worst of impacts. You gain the following benefits:\n \u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit."
+          "description": "Your skill and cunning allows you to avoid the worst of impacts. You gain the following benefits:\n\u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Brain Shake (6 HP, 1 action)",
@@ -4177,10 +4247,11 @@
           "description": "Golden light of obstinance heightens an ally\u2019s ability to deliver punishment. Choose a creature within range. For 1 minute, attacks the creature makes score a Critical hit if the result of each d6 is a 5 or higher."
         }
       ],
-      "background": "Tam Lin is a famous fairy who was said to haunt Carterhaugh Wood in England. He supposedly lured young women away to ruin them. He was once a human who had been trapped by the Fairy Queen. A young woman named Janet is said to have fallen in love with him at one point, and finally managed to free him.\n"
+      "background": "Tam Lin is a famous fairy who was said to haunt Carterhaugh Wood in England. He supposedly lured young women away to ruin them. He was once a human who had been trapped by the Fairy Queen. A young woman named Janet is said to have fallen in love with him at one point, and finally managed to free him."
     },
     {
-      "name": "Ara Mitama",
+      "name": "ara-mitama",
+      "displayName": "Ara Mitama",
       "evolvesTo": null,
       "primaryElement": "Nuke",
       "level": "10",
@@ -4222,7 +4293,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 1d4 + 2 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 1d4 + 2 physical damage."
         },
         {
           "name": "Freila (8 SP, 1 action)",
@@ -4237,10 +4308,11 @@
           "description": "A rallying cry and magic reinforcement strengthens your entire group. Choose up to six creatures within range (90 feet). Those creatures gain the effects of Tarukaja."
         }
       ],
-      "background": "In Japanese belief, Ara Mitama represents aggression and forcefulness and is the source of valor, anger, passion and other heated emotions. It is said to be the more wild and untamed side of the dualistic nature of the spirit. It is usually considered opposite to Nigi Mitama.\n"
+      "background": "In Japanese belief, Ara Mitama represents aggression and forcefulness and is the source of valor, anger, passion and other heated emotions. It is said to be the more wild and untamed side of the dualistic nature of the spirit. It is usually considered opposite to Nigi Mitama."
     },
     {
-      "name": "Ariadne",
+      "name": "ariadne",
+      "displayName": "Ariadne",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "10",
@@ -4279,13 +4351,13 @@
       "traits": [
         {
           "name": "Tag Team",
-          "description": "Cooperation can mitigate costs for body and soul. You gain the following benefits:\n \u2022 If an ally uses an ability with an action granted by you Baton Passing to them, the ally\u2019s use of that ability is not expended (for example, if an ally uses Down Shot with an action granted by your Baton Pass, their use of Down Shot is not expended).\n \u2022 Whenever you perform a Baton Pass to grant an extra action to an ally, you regain 1d8 + half your level Spell Points (min 1)."
+          "description": "Cooperation can mitigate costs for body and soul. You gain the following benefits:\n\u2022 If an ally uses an ability with an action granted by you Baton Passing to them, the ally\u2019s use of that ability is not expended (for example, if an ally uses Down Shot with an action granted by your Baton Pass, their use of Down Shot is not expended).\n\u2022 Whenever you perform a Baton Pass to grant an extra action to an ally, you regain 1d8 + half your level Spell Points (min 1)."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 1d4 + 2 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 1d4 + 2 physical damage."
         },
         {
           "name": "Beast Weaver (15 HP, 1 action)",
@@ -4300,11 +4372,12 @@
           "description": "You begin amassing your strength and stamina, coalescing into an ultimate strike. The next damage roll you make for an attack that deals Physical or Gun damage within the next 10 minutes is doubled"
         }
       ],
-      "background": "Ariadne was the daughter of King Minos of Crete, the owner of the Minotaur. When Theseus came to Crete to end Minos's annual demands that Athens send 7 men and 7 women to sacrifice to the Minotaur, Ariadne fell in love with Theseus. She gave him a sword to fight the Minotaur and a ball of string so he would be able to find his way out of the labyrinth\n"
+      "background": "Ariadne was the daughter of King Minos of Crete, the owner of the Minotaur. When Theseus came to Crete to end Minos's annual demands that Athens send 7 men and 7 women to sacrifice to the Minotaur, Ariadne fell in love with Theseus. She gave him a sword to fight the Minotaur and a ball of string so he would be able to find his way out of the labyrinth"
     },
     {
-      "name": "Kurama Tengu",
-      "evolvesTo": "Yoshitsune",
+      "name": "kurama-tengu",
+      "displayName": "Kurama Tengu",
+      "evolvesTo": "yoshitsune",
       "primaryElement": "Support",
       "level": "10",
       "arcana": "Hermit",
@@ -4346,7 +4419,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 1d6 + 2 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 1d6 + 2 physical damage."
         },
         {
           "name": "Masukunda (24 SP, 2 actions)",
@@ -4361,10 +4434,11 @@
           "description": "A twister lifts up a foe in its clutches, causing them to stutter and lose balance. Make a ranged attack against a creature within range (+5 to hit, 60 feet). On a hit, they receive 2d8 + 2 wind damage"
         }
       ],
-      "background": "Kurama Tengu (\u978d\u99ac\u5929\u72d7) are the most powerful and well-known of the Japanese Tengu who were said to live in Mt. Kurama in Kyoto. The Kurama-Tengu are not only said to be exceptional warriors, but also have the ability to fend off disease and bring good luck.\n The king of the tengu, S\u014dj\u014db\u014d (\u50e7\u6b63\u574a), is one of the Kurama Tengu, and in the 12th century was said to have taught Ushiwakamaru, the future famous warrior Minamoto No Yoshitsune, the arts of swordsmanship, tactics and magic.\n"
+      "background": "Kurama Tengu (\u978d\u99ac\u5929\u72d7) are the most powerful and well-known of the Japanese Tengu who were said to live in Mt. Kurama in Kyoto. The Kurama-Tengu are not only said to be exceptional warriors, but also have the ability to fend off disease and bring good luck.\n\nThe king of the tengu, S\u014dj\u014db\u014d (\u50e7\u6b63\u574a), is one of the Kurama Tengu, and in the 12th century was said to have taught Ushiwakamaru, the future famous warrior Minamoto No Yoshitsune, the arts of swordsmanship, tactics and magic."
     },
     {
-      "name": "Neko Shogun",
+      "name": "neko-shogun",
+      "displayName": "Neko Shogun",
       "evolvesTo": null,
       "primaryElement": "Psychic",
       "level": "10",
@@ -4404,13 +4478,13 @@
       "traits": [
         {
           "name": "Defense Master",
-          "description": "You have a unique sense for defensive tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Rakukaja Skill at no cost or action"
+          "description": "You have a unique sense for defensive tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Rakukaja Skill at no cost or action"
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 1d6 + 2 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 1d6 + 2 physical damage."
         },
         {
           "name": "Psio (8 SP, 1 action)",
@@ -4425,11 +4499,12 @@
           "description": "You accelerate each of your allies to rapid speeds. Choose up to six creatures within range (90 feet). Those creatures gain the effects of Sukukaja."
         }
       ],
-      "background": "Neko Shogun is a divine general in the image of a cat. Originally, he was a Chinese general who conquered Vietnam: Mao Shangshu (\u6bdb\u5c1a\u66f8). The people decided to dedicate a temple to him and worship him as god. However, due to the surname Mao (\u6bdb) sounding very similar to the Chinese word for cat (\u8c93), the temple was accidentally misnamed. Thus, the Temple of General Mao became known as Temple of General Cat (\u8c93\u5c07\u8ecd).\n"
+      "background": "Neko Shogun is a divine general in the image of a cat. Originally, he was a Chinese general who conquered Vietnam: Mao Shangshu (\u6bdb\u5c1a\u66f8). The people decided to dedicate a temple to him and worship him as god. However, due to the surname Mao (\u6bdb) sounding very similar to the Chinese word for cat (\u8c93), the temple was accidentally misnamed. Thus, the Temple of General Mao became known as Temple of General Cat (\u8c93\u5c07\u8ecd)."
     },
     {
-      "name": "Principality",
-      "evolvesTo": "Power",
+      "name": "principality",
+      "displayName": "Principality",
+      "evolvesTo": "power",
       "primaryElement": "Bless",
       "level": "10",
       "arcana": "Justice",
@@ -4472,11 +4547,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 1d6 + 2 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 1d6 + 2 physical damage."
         },
         {
           "name": "Kouga (8 SP, 1 action)",
-          "description": "Twin blades of pure light manifest, puncturing the foe on each side. Make a ranged attack against a creature within range (+4 to hit, 60 feet). On a hit, they receive \u000b4d8 + 3 bless damage"
+          "description": "Twin blades of pure light manifest, puncturing the foe on each side. Make a ranged attack against a creature within range (+4 to hit, 60 feet). On a hit, they receive\n4d8 + 3 bless damage"
         },
         {
           "name": "Makajamaon (10 SP, 2 actions)",
@@ -4487,11 +4562,12 @@
           "description": "Divine strength fills your allies, warding them from peril. Choose up to six creatures within range (90 feet). The next time, within the next 10 minutes, they would instantly be reduced to 0 hit points from a Hama or Mudo type Skill, or from Door of Hades, the effect is prevented completely."
         }
       ],
-      "background": "Principalities, also known as Rulers, are angels of the Third Sphere in Christian angelology with the duty to carry out the orders given to them by the Dominions and bequeath blessings to the material world. The Principalities preside over bands of angels and charge them with fulfilling the divine ministry. Their task is to oversee groups of people. They are usually controlled by the chief angel Erebiel.\n"
+      "background": "Principalities, also known as Rulers, are angels of the Third Sphere in Christian angelology with the duty to carry out the orders given to them by the Dominions and bequeath blessings to the material world. The Principalities preside over bands of angels and charge them with fulfilling the divine ministry. Their task is to oversee groups of people. They are usually controlled by the chief angel Erebiel."
     },
     {
-      "name": "Zouchouten",
-      "evolvesTo": "Koumokuten",
+      "name": "zouchouten",
+      "displayName": "Zouchouten",
+      "evolvesTo": "koumokuten",
       "primaryElement": "Physical",
       "level": "10",
       "arcana": "Strength",
@@ -4526,13 +4602,13 @@
       "traits": [
         {
           "name": "Sharp Student",
-          "description": "Your skill and cunning allows you to avoid the worst of impacts. You gain the following benefits:\n \u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit"
+          "description": "Your skill and cunning allows you to avoid the worst of impacts. You gain the following benefits:\n\u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit"
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 1d8 + 3 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 1d8 + 3 physical damage."
         },
         {
           "name": "Giant Slice (5 HP, 1 action)",
@@ -4540,18 +4616,19 @@
         },
         {
           "name": "Zionga (8 SP, 1 action)",
-          "description": "Streams of uncontrolled electricity rain upon a small area. Make a ranged attack against each creature within a 10-feet radius sphere centered at a point within range \u000b(+2 to hit, 30 feet). On a hit, they receive 1d8 + 2 electric damage. If each d6 in the attack roll is a 4 or higher, the target is also Shocked (see \u201cConditions\u201d)"
+          "description": "Streams of uncontrolled electricity rain upon a small area. Make a ranged attack against each creature within a 10-feet radius sphere centered at a point within range\n(+2 to hit, 30 feet). On a hit, they receive 1d8 + 2 electric damage. If each d6 in the attack roll is a 4 or higher, the target is also Shocked (see \u201cConditions\u201d)"
         },
         {
           "name": "Swift Strike (8 HP, 2 actions)",
-          "description": "You deftly strike at each foe with blinding speed within an area. Make two melee attacks against each creature within a 20-foot sphere centered at a point within range (+2 to hit, 20 feet). For each hit, a creature receives \u000b1d8 + 3 physical damage."
+          "description": "You deftly strike at each foe with blinding speed within an area. Make two melee attacks against each creature within a 20-foot sphere centered at a point within range (+2 to hit, 20 feet). For each hit, a creature receives\n1d8 + 3 physical damage."
         }
       ],
-      "background": "Zouchouten (\u5897\u9577\u5929), also known by the Sanskrit name Vir\u016b\u1e0dhaka, is the guardian deity that guards the South of Buddha's realm. His name means \"lengthening good deeds among mortals.\" He has green skin and leads the troop of Kumbhandas and Pretas. His statues usually carry either a sword or polearm.\n"
+      "background": "Zouchouten (\u5897\u9577\u5929), also known by the Sanskrit name Vir\u016b\u1e0dhaka, is the guardian deity that guards the South of Buddha's realm. His name means \"lengthening good deeds among mortals.\" He has green skin and leads the troop of Kumbhandas and Pretas. His statues usually carry either a sword or polearm."
     },
     {
-      "name": "Anubis",
-      "evolvesTo": "Thoth",
+      "name": "anubis",
+      "displayName": "Anubis",
+      "evolvesTo": "thoth",
       "primaryElement": "Curse",
       "level": "11",
       "arcana": "Judgement",
@@ -4594,7 +4671,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 1d4 + 2 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 1d4 + 2 physical damage."
         },
         {
           "name": "Mudoon (12 SP, 1 action)",
@@ -4602,18 +4679,19 @@
         },
         {
           "name": "Hamaon (12 SP, 1 action)",
-          "description": "Divine will and an excess of banishing rights and rituals consecrate the creature\u2019s space, purging it of evil and existence. Choose a creature within range and make a ranged attack against them (+4 to hit, 90 feet). On a hit, if the result of each d6 is 3 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Bless. This Skill provokes a \u000bOne More if the target is weak to Bless."
+          "description": "Divine will and an excess of banishing rights and rituals consecrate the creature\u2019s space, purging it of evil and existence. Choose a creature within range and make a ranged attack against them (+4 to hit, 90 feet). On a hit, if the result of each d6 is 3 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Bless. This Skill provokes a\nOne More if the target is weak to Bless."
         },
         {
           "name": "Dekunda (12 SP, 2 actions)",
           "description": "You cleanse impurities of the heart. Choose up to six creatures within range (90 feet). All effects of Tarunda, Rakunda, Sukunda are removed from them."
         }
       ],
-      "background": "Anubis is widely known as the Egyptian deity of mummification. In this role, he oversees the mummification process of the dead, and is usually seen in hieroglyphic tomb-carvings as overseeing the burial ritual for the pharaohs and those of royal lineage; this is due to the priest involved wearing the masks of Anubis to symbolize him as the overseer of the ritual.\n"
+      "background": "Anubis is widely known as the Egyptian deity of mummification. In this role, he oversees the mummification process of the dead, and is usually seen in hieroglyphic tomb-carvings as overseeing the burial ritual for the pharaohs and those of royal lineage; this is due to the priest involved wearing the masks of Anubis to symbolize him as the overseer of the ritual."
     },
     {
-      "name": "Decarabia",
-      "evolvesTo": "Ose",
+      "name": "decarabia",
+      "displayName": "Decarabia",
+      "evolvesTo": "ose",
       "primaryElement": "Fire",
       "level": "11",
       "arcana": "Councillor",
@@ -4651,13 +4729,13 @@
       "traits": [
         {
           "name": "Thermal Conduct",
-          "description": "Conductive energies overheat a vulnerable foe. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with Burn (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage"
+          "description": "Conductive energies overheat a vulnerable foe. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with Burn (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage"
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +6 to hit, range 5 ft., one target. \u000bHit: 1d4 + 3 physical damage."
+          "description": "Melee attack: +6 to hit, range 5 ft., one target.\nHit: 1d4 + 3 physical damage."
         },
         {
           "name": "Agidyne (16 SP, 1 action)",
@@ -4672,11 +4750,12 @@
           "description": "Glowing, star-like spheres manifest above the field, then fire beams of destructive force by the dozens into foes. Make a ranged attack against up to six creatures within range (60 feet). On a hit, they receive 2d8 + 3 almighty damage."
         }
       ],
-      "background": "Decarabia, also known as Carabia, is the sixty-ninth demonic spirit listed in Ars Goetia, according to the writings in the Lesser Key of Solomon. Although he has no title in the Pseudomonarchia Daemonum, he does in the Lesser Key of Solomon where he is a Great Marquis of Hell and has thirty legions of demons under his command.\n When summoned, Decarabia appears as a pentagram star, although he will take the form of a man if the conjurer requests it. He knows the properties and values of all herbs and precious stones, and can transform into any type of bird to sing and fly for his conjurer, sometimes acting as his animal familiar.\n"
+      "background": "Decarabia, also known as Carabia, is the sixty-ninth demonic spirit listed in Ars Goetia, according to the writings in the Lesser Key of Solomon. Although he has no title in the Pseudomonarchia Daemonum, he does in the Lesser Key of Solomon where he is a Great Marquis of Hell and has thirty legions of demons under his command.\n\nWhen summoned, Decarabia appears as a pentagram star, although he will take the form of a man if the conjurer requests it. He knows the properties and values of all herbs and precious stones, and can transform into any type of bird to sing and fly for his conjurer, sometimes acting as his animal familiar."
     },
     {
-      "name": "Lachesis",
-      "evolvesTo": "Atropos",
+      "name": "lachesis",
+      "displayName": "Lachesis",
+      "evolvesTo": "atropos",
       "primaryElement": "Ice",
       "level": "11",
       "arcana": "Fortune",
@@ -4719,7 +4798,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +6 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: +6 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Bufula (8 SP, 1 action)",
@@ -4734,11 +4813,12 @@
           "description": "You coordinate the defense of your allies, covering flanks and shielding them from danger. Choose up to six creatures within range. Those creatures gain the effects of Rakukaja."
         }
       ],
-      "background": "In Greek mythology, Lachesis, also known as Lakhesis (\"disperser of lots\"), was the second of the Moirae Sisters, or Moirae. She was the apportioner, deciding how much time for life was to be allowed for each person or being. She measured the thread of life with her rod. She is also said to choose a person's destiny after a thread was measured.\n"
+      "background": "In Greek mythology, Lachesis, also known as Lakhesis (\"disperser of lots\"), was the second of the Moirae Sisters, or Moirae. She was the apportioner, deciding how much time for life was to be allowed for each person or being. She measured the thread of life with her rod. She is also said to choose a person's destiny after a thread was measured."
     },
     {
-      "name": "Lilim",
-      "evolvesTo": "Lilith",
+      "name": "lilim",
+      "displayName": "Lilim",
+      "evolvesTo": "lilith",
       "primaryElement": "Ice",
       "level": "11",
       "arcana": "Devil",
@@ -4776,13 +4856,13 @@
       "traits": [
         {
           "name": "Cold-Blooded",
-          "description": "With reptilian cruelty, you freeze a foe. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with Freeze (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "With reptilian cruelty, you freeze a foe. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with Freeze (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +7 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: +7 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Bufula (8 SP, 1 action)",
@@ -4794,14 +4874,15 @@
         },
         {
           "name": "Spirit Drain (5 SP, 1 action)",
-          "description": "You sate your aural thirst with the magical powers and thoughts of your foe, absorbing their essence. Make a ranged attack against a creature within range \u000b(+5 to hit, 30 feet). On a hit, the creature loses and you regain \u000b8 Spell Points."
+          "description": "You sate your aural thirst with the magical powers and thoughts of your foe, absorbing their essence. Make a ranged attack against a creature within range\n(+5 to hit, 30 feet). On a hit, the creature loses and you regain\n8 Spell Points."
         }
       ],
-      "background": "The Lilim, or Lilin, are dangerous demons similar to succubi that reside in Hell. The Lilim were conceived through Lilith alone, though some of them came from the union of herself and Samael, the angel of death.\n Men feared the Lilim for this reason and women also feared the Lilim because it is believed that they kidnap children like their mother Lilith. They are amazingly beautiful and strongly resemble their mother. The Lilim are said to bring harm to human children, and to seduce men who are caught in their gaze. Like their mother, they drain men of their essence.\n"
+      "background": "The Lilim, or Lilin, are dangerous demons similar to succubi that reside in Hell. The Lilim were conceived through Lilith alone, though some of them came from the union of herself and Samael, the angel of death.\n\nMen feared the Lilim for this reason and women also feared the Lilim because it is believed that they kidnap children like their mother Lilith. They are amazingly beautiful and strongly resemble their mother. The Lilim are said to bring harm to human children, and to seduce men who are caught in their gaze. Like their mother, they drain men of their essence."
     },
     {
-      "name": "Mitra",
-      "evolvesTo": "Pazuzu",
+      "name": "mitra",
+      "displayName": "Mitra",
+      "evolvesTo": "pazuzu",
       "primaryElement": "Bless",
       "level": "11",
       "arcana": "Temperance",
@@ -4843,11 +4924,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +6 to hit, range 5 ft., one target. \u000bHit: 1d4 + 1 physical damage."
+          "description": "Melee attack: +6 to hit, range 5 ft., one target.\nHit: 1d4 + 1 physical damage."
         },
         {
           "name": "Kouga (8 SP, 1 action)",
-          "description": "Twin blades of pure light manifest, puncturing the foe on each side. Make a ranged attack against a creature within range (+4 to hit, 60 feet). On a hit, they receive \u000b4d8 + 4 bless damage"
+          "description": "Twin blades of pure light manifest, puncturing the foe on each side. Make a ranged attack against a creature within range (+4 to hit, 60 feet). On a hit, they receive\n4d8 + 4 bless damage"
         },
         {
           "name": "Diarama (9 SP, 1 action)",
@@ -4855,13 +4936,14 @@
         },
         {
           "name": "Thermopylae (24 SP, 2 actions)",
-          "description": "The intense heat of battle allows you to turn the tide. Choose up to six creatures within range \u000b(90 feet). Those creatures gain the effects of Tarukaja, Rakukaja, and Sukukaja. This Skill may only affect creatures with only half of their hit points remaining or less."
+          "description": "The intense heat of battle allows you to turn the tide. Choose up to six creatures within range\n(90 feet). Those creatures gain the effects of Tarukaja, Rakukaja, and Sukukaja. This Skill may only affect creatures with only half of their hit points remaining or less."
         }
       ],
-      "background": "In Zoroastrian mythology, Mithra was a deity of contracts who was the protector of truth and the enemy of error. He was created by the supreme deity Ahura Mazda as the greatest of all Yazatas and an important aid in the destruction of the demonic forces led by Angra Mainyu (also known as Ahriman) in later Persian sources. He was one of the three Yazatas alongside Rashnu and Sraosha who judged the souls of the dead.\n"
+      "background": "In Zoroastrian mythology, Mithra was a deity of contracts who was the protector of truth and the enemy of error. He was created by the supreme deity Ahura Mazda as the greatest of all Yazatas and an important aid in the destruction of the demonic forces led by Angra Mainyu (also known as Ahriman) in later Persian sources. He was one of the three Yazatas alongside Rashnu and Sraosha who judged the souls of the dead."
     },
     {
-      "name": "Mothman",
+      "name": "mothman",
+      "displayName": "Mothman",
       "evolvesTo": null,
       "primaryElement": "Electric",
       "level": "11",
@@ -4899,32 +4981,33 @@
       "traits": [
         {
           "name": "Static Electricity",
-          "description": "An overabundance of electrical power primes a foe for paralysis. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with Shock (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "An overabundance of electrical power primes a foe for paralysis. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with Shock (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +7 to hit, range 5 ft., one target. \u000bHit: 1d4 + 2 physical damage."
+          "description": "Melee attack: +7 to hit, range 5 ft., one target.\nHit: 1d4 + 2 physical damage."
         },
         {
           "name": "Ziodyne (16 SP, 1 action)",
-          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+5 to hit, 30 feet). On a hit, they receive \u000b3d8 + 2 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
+          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+5 to hit, 30 feet). On a hit, they receive\n3d8 + 2 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
         },
         {
           "name": "Life Leech (10 SP, 1 action)",
-          "description": "You voraciously devour a foe\u2019s life force. Make a ranged attack against a creature within range \u000b(+5 to hit, 30 feet). On a hit, the creature receives almighty damage, and you regain hit points equal to 2d8 + 2."
+          "description": "You voraciously devour a foe\u2019s life force. Make a ranged attack against a creature within range\n(+5 to hit, 30 feet). On a hit, the creature receives almighty damage, and you regain hit points equal to 2d8 + 2."
         },
         {
           "name": "Tentarafoo (10 SP, 2 actions)",
           "description": "Many tendrils swirl about, poised, then burrow into the minds of a battlefield to unsettle all. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range (+5 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Confuse (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Mothman is a cryptid of American origin. In the mid-1960s, there were some sightings of a great winged creature with massive reddish eyes. It is thought (outside of cryptozoology) that these might actually be misconstrued sandhill cranes or barn owls.\n"
+      "background": "Mothman is a cryptid of American origin. In the mid-1960s, there were some sightings of a great winged creature with massive reddish eyes. It is thought (outside of cryptozoology) that these might actually be misconstrued sandhill cranes or barn owls."
     },
     {
-      "name": "Thunderbird",
-      "evolvesTo": "Jatayu",
+      "name": "thunderbird",
+      "displayName": "Thunderbird",
+      "evolvesTo": "jatayu",
       "primaryElement": "Electric",
       "level": "11",
       "arcana": "Sun",
@@ -4966,11 +5049,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 1d4 + 2 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 1d4 + 2 physical damage."
         },
         {
           "name": "Ziodyne (16 SP, 1 action)",
-          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+5 to hit, 30 feet). On a hit, they receive \u000b5d8 + 2 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
+          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+5 to hit, 30 feet). On a hit, they receive\n5d8 + 2 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
         },
         {
           "name": "Tarukaja (8 SP, 1 action)",
@@ -4981,11 +5064,12 @@
           "description": "Golden light of obstinance heightens an ally\u2019s ability to deliver punishment. Choose a creature within range (90 feet). For 1 minute, attacks the creature makes score a Critical hit if the result of each d6 is a 5 or higher."
         }
       ],
-      "background": "The thunderbird is a legendary creature found in Native American folklore. It's considered a \"supernatural\" bird of power and strength. It is especially important, and richly depicted, in the art, songs and oral histories of many Pacific Northwest Coast cultures, and is found in various forms among the peoples of the American Southwest and Great Plains. Thunderbirds were major components of the Southeastern Ceremonial Complex of American prehistory. The Thunderbird's name comes from the common belief that the beating of its enormous wings causes thunder and stirs the wind.\n"
+      "background": "The thunderbird is a legendary creature found in Native American folklore. It's considered a \"supernatural\" bird of power and strength. It is especially important, and richly depicted, in the art, songs and oral histories of many Pacific Northwest Coast cultures, and is found in various forms among the peoples of the American Southwest and Great Plains. Thunderbirds were major components of the Southeastern Ceremonial Complex of American prehistory. The Thunderbird's name comes from the common belief that the beating of its enormous wings causes thunder and stirs the wind."
     },
     {
-      "name": "Arahabaki",
-      "evolvesTo": "Nyarlathotep",
+      "name": "arahabaki",
+      "displayName": "Arahabaki",
+      "evolvesTo": "nyarlathotep",
       "primaryElement": "Support",
       "level": "12",
       "arcana": "Hermit",
@@ -5030,7 +5114,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Makarakarn (20 SP, 1 action)",
@@ -5042,14 +5126,15 @@
         },
         {
           "name": "Spirit Drain (5 SP, 1 action)",
-          "description": "You sate your aural thirst with the magical powers and thoughts of your foe, absorbing their essence. Make a ranged attack against a creature within range \u000b(+3 to hit, 30 feet). On a hit, the creature loses and you regain \u000b8 Spell Points."
+          "description": "You sate your aural thirst with the magical powers and thoughts of your foe, absorbing their essence. Make a ranged attack against a creature within range\n(+3 to hit, 30 feet). On a hit, the creature loses and you regain\n8 Spell Points."
         }
       ],
-      "background": "Arahabaki is a Japanese god of uncertain origin. His portrayal in the Megami Tensei franchise is influenced by Tsugaru Soto-Sangunshi, a forgery compiled in the 1970s. The contents of the document and even the circumstances in which it was purportedly found prove that it was not genuine[1], but due to coverage in occult magazines between the 1970s and early 2000s it's relatively often referenced in pop culture. Inaccuracies include descriptions of natural disasters which never happened, scientific discoveries stated to occur in incorrect time periods, and references to XXth century urban legends in purported XVIIIth century chronicles. Arahabaki is also stated to be a god exclusively associated with the Tohoku region in it - however, most place names related to this deity aren't even located in the north[2].\n"
+      "background": "Arahabaki is a Japanese god of uncertain origin. His portrayal in the Megami Tensei franchise is influenced by Tsugaru Soto-Sangunshi, a forgery compiled in the 1970s. The contents of the document and even the circumstances in which it was purportedly found prove that it was not genuine[1], but due to coverage in occult magazines between the 1970s and early 2000s it's relatively often referenced in pop culture. Inaccuracies include descriptions of natural disasters which never happened, scientific discoveries stated to occur in incorrect time periods, and references to XXth century urban legends in purported XVIIIth century chronicles. Arahabaki is also stated to be a god exclusively associated with the Tohoku region in it - however, most place names related to this deity aren't even located in the north[2]."
     },
     {
-      "name": "Belphegor",
-      "evolvesTo": "Narcissus",
+      "name": "belphegor",
+      "displayName": "Belphegor",
+      "evolvesTo": "narcissus",
       "primaryElement": "Ice",
       "level": "12",
       "arcana": "Tower",
@@ -5094,7 +5179,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 1d8 + 4 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 1d8 + 4 physical damage."
         },
         {
           "name": "Bufudyne (16 SP, 1 action)",
@@ -5109,11 +5194,12 @@
           "description": "You gather and focus your mind's eye, delivering an absolute force of will. The next damage roll you make for an attack that deals Fire, Ice, Electric, Wind, Psychic, Nuke, Bless, Curse, or Almighty damage within the next 10 minutes is doubled."
         }
       ],
-      "background": "Belphegor is the demon lord of Sloth, one of the 7 Deadly Sins and a member of the Seven Princes of Hell. Belphegor gives people ideas for inventions that will make them rich and thus greedy and selfish. He was known as a phallic deity, associated with sex, orgies, and all forms of debauchery in general.\n"
+      "background": "Belphegor is the demon lord of Sloth, one of the 7 Deadly Sins and a member of the Seven Princes of Hell. Belphegor gives people ideas for inventions that will make them rich and thus greedy and selfish. He was known as a phallic deity, associated with sex, orgies, and all forms of debauchery in general."
     },
     {
-      "name": "Hell Biker",
-      "evolvesTo": "Macabre",
+      "name": "hell-biker",
+      "displayName": "Hell Biker",
+      "evolvesTo": "macabre",
       "primaryElement": "Fire",
       "level": "12",
       "arcana": "Death",
@@ -5150,13 +5236,13 @@
       "traits": [
         {
           "name": "Speed Master",
-          "description": "You have a unique sense for agile tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Sukukaja Skill at no cost or action."
+          "description": "You have a unique sense for agile tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Sukukaja Skill at no cost or action."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 1d8 + 2 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 1d8 + 2 physical damage."
         },
         {
           "name": "Agilao (8 SP, 1 action)",
@@ -5171,11 +5257,12 @@
           "description": "Many tendrils swirl about, poised, then burrow into the minds of a battlefield to unsettle all. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range (+5 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Confuse (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Hell Biker's name in Japanese versions refers to Hells Angels, an American biker gang formed in 1948.\n Hell Biker is a human motorcyclist whose violent nature and hatred of himself and the world had turned him into a demon. He claims to come from hell, clothed all in black, a red scarf streaming, he rides full of rage calling himself the \"Angel of Hell\". His anger with himself and the world causes him to lash out, that everyone else would suffer as well."
+      "background": "Hell Biker's name in Japanese versions refers to Hells Angels, an American biker gang formed in 1948.\n\nHell Biker is a human motorcyclist whose violent nature and hatred of himself and the world had turned him into a demon. He claims to come from hell, clothed all in black, a red scarf streaming, he rides full of rage calling himself the \"Angel of Hell\". His anger with himself and the world causes him to lash out, that everyone else would suffer as well."
     },
     {
-      "name": "Kaiwan",
-      "evolvesTo": "Byakhee",
+      "name": "kaiwan",
+      "displayName": "Kaiwan",
+      "evolvesTo": "byakhee",
       "primaryElement": "Psychic",
       "level": "12",
       "arcana": "Star",
@@ -5211,13 +5298,13 @@
       "traits": [
         {
           "name": "Speed Master",
-          "description": "You have a unique sense for agile tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Sukukaja Skill at no cost or action."
+          "description": "You have a unique sense for agile tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Sukukaja Skill at no cost or action."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 1d6 + 2 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 1d6 + 2 physical damage."
         },
         {
           "name": "Psiodyne (16 SP, 1 action)",
@@ -5232,11 +5319,12 @@
           "description": "You expose the weakest points of a group of foes, allowing for allies to move in. Choose up to six creatures within range (90 feet). Those creatures gain the effects of Rakunda."
         }
       ],
-      "background": "Kaiwan (or Kiyyun) was a deity worshiped by some of the Israelites according to the Book of Amos. Amos 5:26 refers to \"the star of your god.\" His name appears to be derived from the Babylonian name of the planet Saturn. Others suggest that the name comes from a Hebrew root word that refers to something on a pedestal or image stand, and might refer to an idol of another deity rather than a separate god.\n"
+      "background": "Kaiwan (or Kiyyun) was a deity worshiped by some of the Israelites according to the Book of Amos. Amos 5:26 refers to \"the star of your god.\" His name appears to be derived from the Babylonian name of the planet Saturn. Others suggest that the name comes from a Hebrew root word that refers to something on a pedestal or image stand, and might refer to an idol of another deity rather than a separate god."
     },
     {
-      "name": "Thoth",
-      "evolvesTo": "Horus",
+      "name": "thoth",
+      "displayName": "Thoth",
+      "evolvesTo": "horus",
       "primaryElement": "Almighty",
       "level": "12",
       "arcana": "Emperor",
@@ -5280,7 +5368,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 1d4 + 2 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 1d4 + 2 physical damage."
         },
         {
           "name": "Megido (12 SP, 2 actions)",
@@ -5295,10 +5383,11 @@
           "description": "You gather and focus your mind's eye, delivering an absolute force of will. The next damage roll you make for an attack that deals Fire, Ice, Electric, Wind, Psychic, Nuke, Bless, Curse, or Almighty damage within the next 10 minutes is doubled."
         }
       ],
-      "background": "Thoth, also known as Djehuti, is one of the most important gods in Egyptian mythology, commonly depicted as a man with either the head of an ibis or a baboon. He was said to be self-created or born of the seed of Horus from the forehead of Set. According to one story, Thoth was born \"from the lips of Ra\" at the beginning of creation and was known as the \"god without a mother.\" In another tale, Thoth is self-created at the beginning of time and, as an ibis, lays the cosmic egg which holds all of creation.\n"
+      "background": "Thoth, also known as Djehuti, is one of the most important gods in Egyptian mythology, commonly depicted as a man with either the head of an ibis or a baboon. He was said to be self-created or born of the seed of Horus from the forehead of Set. According to one story, Thoth was born \"from the lips of Ra\" at the beginning of creation and was known as the \"god without a mother.\" In another tale, Thoth is self-created at the beginning of time and, as an ibis, lays the cosmic egg which holds all of creation."
     },
     {
-      "name": "Atropos",
+      "name": "atropos",
+      "displayName": "Atropos",
       "evolvesTo": null,
       "primaryElement": "Electric",
       "level": "13",
@@ -5334,17 +5423,17 @@
       "traits": [
         {
           "name": "Flow",
-          "description": "Momentum lifts you up and carries you forward. You gain the following benefits:\n \u2022 Whenever you roll Initiative, roll 1d4. On a 4, you gain the benefits of Power Charge and Concentrate at no cost."
+          "description": "Momentum lifts you up and carries you forward. You gain the following benefits:\n\u2022 Whenever you roll Initiative, roll 1d4. On a 4, you gain the benefits of Power Charge and Concentrate at no cost."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 1d4 + 2 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 1d4 + 2 physical damage."
         },
         {
           "name": "Ziodyne (16 SP, 1 action)",
-          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+5 to hit, 30 feet). On a hit, they receive \u000b3d8 + 4 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
+          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+5 to hit, 30 feet). On a hit, they receive\n3d8 + 4 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
         },
         {
           "name": "Mediarama (18 SP, 2 actions)",
@@ -5355,11 +5444,12 @@
           "description": "You reach out your hand, and crush a foe\u2019s resilience to your attack. When you use this Skill, choose Fire, Ice, Electric, Wind, Psychic, or Nuke and up to six creatures within range (90 feet). For the next three rounds starting to count down at the end of this one, those creatures no longer Resist, Block, Drain, or Repel the chosen damage type. Additionally, this Skill removes all Tetrakarn and Makarakarn effects from affected creatures."
         }
       ],
-      "background": "Atropos is the eldest of the three Moirae Sisters, and was known as \"the Inflexible One\". She is the one who cuts the thread of fate, signifying the end of one's life. They controlled the destiny of every living mortal and it was thought that even Zeus was subject to their will, unable to change it; in a few myths, however, Zeus was named \"Moiragetes\", i.e. controller of the Fates.\n"
+      "background": "Atropos is the eldest of the three Moirae Sisters, and was known as \"the Inflexible One\". She is the one who cuts the thread of fate, signifying the end of one's life. They controlled the destiny of every living mortal and it was thought that even Zeus was subject to their will, unable to change it; in a few myths, however, Zeus was named \"Moiragetes\", i.e. controller of the Fates."
     },
     {
-      "name": "Daisoujou",
-      "evolvesTo": "Trumpeter",
+      "name": "daisoujou",
+      "displayName": "Daisoujou",
+      "evolvesTo": "trumpeter",
       "primaryElement": "Bless",
       "level": "13",
       "arcana": "Hierophant",
@@ -5402,11 +5492,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 1d4 + 3 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 1d4 + 3 physical damage."
         },
         {
           "name": "Spirit Drain (5 SP, 1 action)",
-          "description": "You sate your aural thirst with the magical powers and thoughts of your foe, absorbing their essence. Make a ranged attack against a creature within range \u000b(+3 to hit, 30 feet). On a hit, the creature loses and you regain \u000b9 Spell Points."
+          "description": "You sate your aural thirst with the magical powers and thoughts of your foe, absorbing their essence. Make a ranged attack against a creature within range\n(+3 to hit, 30 feet). On a hit, the creature loses and you regain\n9 Spell Points."
         },
         {
           "name": "Samsara (18 SP, 2 actions)",
@@ -5417,10 +5507,11 @@
           "description": "A cascade of verdant light basks an ally in a healing glow, healing their most grievous injury. Choose a creature within range (90 feet). That creature regains 6d8 + 9 hit points."
         }
       ],
-      "background": "Soujou (\u50e7\u6b63) in historical East Asian regions is any high ranking Buddhist monk appointed by the government in power, in order to manage all the Buddhist temples and monks within the sovereignty's domain. In Japan, Daisoujou (\u5927\u50e7\u6b63) is the top official to hold this position, and there might be two to three more Soujous under Daisoujou depending on the time period, they are Kendaisoujou (\u6a29\u5927\u50e7\u6b63), (simply) Soujou, and Kensoujou (\u6a29\u50e7\u6b63).\n"
+      "background": "Soujou (\u50e7\u6b63) in historical East Asian regions is any high ranking Buddhist monk appointed by the government in power, in order to manage all the Buddhist temples and monks within the sovereignty's domain. In Japan, Daisoujou (\u5927\u50e7\u6b63) is the top official to hold this position, and there might be two to three more Soujous under Daisoujou depending on the time period, they are Kendaisoujou (\u6a29\u5927\u50e7\u6b63), (simply) Soujou, and Kensoujou (\u6a29\u50e7\u6b63)."
     },
     {
-      "name": "Hariti",
+      "name": "hariti",
+      "displayName": "Hariti",
       "evolvesTo": null,
       "primaryElement": "Electric",
       "level": "13",
@@ -5463,7 +5554,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +6 to hit, range 5 ft., one target. \u000bHit: 1d4 + 2 physical damage."
+          "description": "Melee attack: +6 to hit, range 5 ft., one target.\nHit: 1d4 + 2 physical damage."
         },
         {
           "name": "Energy Shower (6 SP, 2 actions)",
@@ -5475,14 +5566,15 @@
         },
         {
           "name": "Zionga (8 SP, 1 action)",
-          "description": "Streams of uncontrolled electricity rain upon a small area. Make a ranged attack against each creature within a 10-feet radius sphere centered at a point within range \u000b(+3 to hit, 30 feet). On a hit, they receive 3d8 + 4 electric damage. If each d6 in the attack roll is a 4 or higher, the target is also Shocked (see \u201cConditions\u201d)"
+          "description": "Streams of uncontrolled electricity rain upon a small area. Make a ranged attack against each creature within a 10-feet radius sphere centered at a point within range\n(+3 to hit, 30 feet). On a hit, they receive 3d8 + 4 electric damage. If each d6 in the attack roll is a 4 or higher, the target is also Shocked (see \u201cConditions\u201d)"
         }
       ],
-      "background": "Hariti is a demoness originating from what is now called Pakistan. She was originally an ogress who slew human children in her desperation to feed her hundreds of children. After the arrival of Buddhism, which came to Pakistan as a missionary religion, the legend of Hariti was given a new twist by Buddhist missionaries; being that, in order to put a stop to this way of feeding on the blood of children, Gautama Buddha hid away Priyankara, one of Hariti's sons, under a rice bowl and then pointed out to her that the suffering she was experiencing from losing one out of her hundreds of children could not be compared to that of the human mothers whose few children became her victims. Remorseful for her deeds, Hariti pledged to become the protector of childbirth and children and converted to Buddhism.\n"
+      "background": "Hariti is a demoness originating from what is now called Pakistan. She was originally an ogress who slew human children in her desperation to feed her hundreds of children. After the arrival of Buddhism, which came to Pakistan as a missionary religion, the legend of Hariti was given a new twist by Buddhist missionaries; being that, in order to put a stop to this way of feeding on the blood of children, Gautama Buddha hid away Priyankara, one of Hariti's sons, under a rice bowl and then pointed out to her that the suffering she was experiencing from losing one out of her hundreds of children could not be compared to that of the human mothers whose few children became her victims. Remorseful for her deeds, Hariti pledged to become the protector of childbirth and children and converted to Buddhism."
     },
     {
-      "name": "Kikuri-Hime",
-      "evolvesTo": "Maria",
+      "name": "kikuri-hime",
+      "displayName": "Kikuri-Hime",
+      "evolvesTo": "maria",
       "primaryElement": "Support",
       "level": "13",
       "arcana": "Priestess",
@@ -5525,7 +5617,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +7 to hit, range 5 ft., one target. \u000bHit: 1d4 + 2 physical damage."
+          "description": "Melee attack: +7 to hit, range 5 ft., one target.\nHit: 1d4 + 2 physical damage."
         },
         {
           "name": "Marakukaja (12 SP, 2 actions)",
@@ -5537,14 +5629,15 @@
         },
         {
           "name": "Energy Drop (4 SP, 1 action)",
-          "description": "A stimulating remedy opens one\u2019s eyes against emotional malady. Choose a creature within range \u000b(60 feet). That creature recovers from Confuse, Fear, Despair, Rage, and Brainwash (see \u201cConditions\u201d)."
+          "description": "A stimulating remedy opens one\u2019s eyes against emotional malady. Choose a creature within range\n(60 feet). That creature recovers from Confuse, Fear, Despair, Rage, and Brainwash (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Kikuri-Hime-no-mikoto (\u83ca\u7406\u59eb or \u83ca\u7406\u5a9b\u547d) means \"Priestess Chrysanthemum.\" Chrysanthemum is her symbolic flower and associated with lamentation at death in East Asian cultures. Kikuri-Hime is briefly mentioned in Nihon Shoki after Izanagi was driven out of Yomotsu Hirasaka (Shinto Netherworld) in his failed attempt to retrieve his late consort, Izanami. Kikuri-Hime mediated on behalf of Izanami so that the husband and wife could engage in a debate in their confrontation in Yomi. The exact content of this debate is not recorded, although there has been much conjecture. It is the actions of Kikuri-Hime that established the duty of Miko (Japanese priestess) of communicating with the netherworld on behalf of the living one. She has also been known as a goddess of matchmaking since ancient times.\n"
+      "background": "Kikuri-Hime-no-mikoto (\u83ca\u7406\u59eb or \u83ca\u7406\u5a9b\u547d) means \"Priestess Chrysanthemum.\" Chrysanthemum is her symbolic flower and associated with lamentation at death in East Asian cultures. Kikuri-Hime is briefly mentioned in Nihon Shoki after Izanagi was driven out of Yomotsu Hirasaka (Shinto Netherworld) in his failed attempt to retrieve his late consort, Izanami. Kikuri-Hime mediated on behalf of Izanami so that the husband and wife could engage in a debate in their confrontation in Yomi. The exact content of this debate is not recorded, although there has been much conjecture. It is the actions of Kikuri-Hime that established the duty of Miko (Japanese priestess) of communicating with the netherworld on behalf of the living one. She has also been known as a goddess of matchmaking since ancient times."
     },
     {
-      "name": "Legion",
-      "evolvesTo": "Abaddon",
+      "name": "legion",
+      "displayName": "Legion",
+      "evolvesTo": "abaddon",
       "primaryElement": "Almighty",
       "level": "13",
       "arcana": "Fool",
@@ -5590,7 +5683,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Life Leech (10 SP, 1 action)",
@@ -5598,18 +5691,19 @@
         },
         {
           "name": "Bloodbath (16 HP, 2 actions)",
-          "description": "Ribbons of dark blades lash out, hacking a field into terrifying ribbons. Make a melee attack against each creature within a 20-foot sphere centered at a point within range (+3 to hit, 20 feet). A creature hit by this attack receives \u000b4d8 + 3 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Fear (see \u201cConditions'')."
+          "description": "Ribbons of dark blades lash out, hacking a field into terrifying ribbons. Make a melee attack against each creature within a 20-foot sphere centered at a point within range (+3 to hit, 20 feet). A creature hit by this attack receives\n4d8 + 3 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Fear (see \u201cConditions'')."
         },
         {
           "name": "Eigaon (16 SP, 1 action)",
           "description": "A portal to despair yawns below a foe\u2019s feet, only to flood them in a wave of pure hatred. Make a ranged attack against a creature within range (+3 to hit, 60 feet). On a hit, they receive 4d8 + 4 curse damage."
         }
       ],
-      "background": "Legion is a collection of demons which was referred in Christian literature. While the types of demons that make up Legion is unknown, they are purportedly said to be the same kind of demon that would inhabit a host and would have a single hive mind. The general form is a floating sphere composed of numerous featureless faces that acts as a shell concealing a center core of varying identity.\n"
+      "background": "Legion is a collection of demons which was referred in Christian literature. While the types of demons that make up Legion is unknown, they are purportedly said to be the same kind of demon that would inhabit a host and would have a single hive mind. The general form is a floating sphere composed of numerous featureless faces that acts as a shell concealing a center core of varying identity."
     },
     {
-      "name": "Mithras",
-      "evolvesTo": "Alilat",
+      "name": "mithras",
+      "displayName": "Mithras",
+      "evolvesTo": "alilat",
       "primaryElement": "Nuke",
       "level": "13",
       "arcana": "Sun",
@@ -5655,7 +5749,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 1d6 + 4 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 1d6 + 4 physical damage."
         },
         {
           "name": "Freidyne (16 SP, 1 action)",
@@ -5670,10 +5764,11 @@
           "description": "Many tendrils swirl about, poised, then burrow into the minds of a battlefield to unsettle all. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range (+3 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Confuse (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Mithras is a sun deity who was worshiped in the Roman empire from the 1st to the 4th century AD and is the patron of Mithraism. He was said to be reborn after death, and a festival was held on the winter solstice for him. It is believed that Mithraism was popular in the Roman military and did not accept female disciples. Whether Mithras was directly inspired by the much older Mithra from Persia or Mitra from ancient India remains debatable. It is today considered a mystery religion due to lack of textual records of the cult, but many Mithraic temples and artifacts survive.\n"
+      "background": "Mithras is a sun deity who was worshiped in the Roman empire from the 1st to the 4th century AD and is the patron of Mithraism. He was said to be reborn after death, and a festival was held on the winter solstice for him. It is believed that Mithraism was popular in the Roman military and did not accept female disciples. Whether Mithras was directly inspired by the much older Mithra from Persia or Mitra from ancient India remains debatable. It is today considered a mystery religion due to lack of textual records of the cult, but many Mithraic temples and artifacts survive."
     },
     {
-      "name": "White Rider",
+      "name": "white-rider",
+      "displayName": "White Rider",
       "evolvesTo": null,
       "primaryElement": "Gun",
       "level": "13",
@@ -5712,17 +5807,17 @@
       "traits": [
         {
           "name": "Ghost Nest",
-          "description": "Ethereal claws of your will aid in penetrating the defenses of others. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with a Condition, roll 1d4. On a 4, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "Ethereal claws of your will aid in penetrating the defenses of others. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with a Condition, roll 1d4. On a 4, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 1d6 + 4 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 1d6 + 4 physical damage."
         },
         {
           "name": "Triple Down (9 HP, 2 actions)",
-          "description": "A trifecta of cunning blows knock a foe asunder. Make three melee attacks against each creature within a 10-foot sphere centered at a point within range \u000b(+4 to hit, 10 feet). For each hit, the creature receives \u000b2d10 + 4 gun damage."
+          "description": "A trifecta of cunning blows knock a foe asunder. Make three melee attacks against each creature within a 10-foot sphere centered at a point within range\n(+4 to hit, 10 feet). For each hit, the creature receives\n2d10 + 4 gun damage."
         },
         {
           "name": "Evil Touch (5 SP, 1 action)",
@@ -5733,11 +5828,12 @@
           "description": "A demonic dance swirls about and punctures foes in vital points. Make a melee attack against up to six creatures within range (+4 to hit, 20 feet). A creature hit by this attack receives 2d8 + 4 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Rage (see \u201cConditions\u201d)."
         }
       ],
-      "background": "The White Rider, or White Horseman, is the first of the Four Horsemen of the Apocalypse to appear before John the Apostle, according to Christian scripture. It traditionally represents conquest, bearing a bow of conquest, with the \"pestilence\" association first appearing in the 20th century. This Horseman is one of confusion amongst theologians as some believe he is representative of divine conquest (and thus a force of good) while others think of him as a representative of unlawful conquest (and thus a force of evil).\n"
+      "background": "The White Rider, or White Horseman, is the first of the Four Horsemen of the Apocalypse to appear before John the Apostle, according to Christian scripture. It traditionally represents conquest, bearing a bow of conquest, with the \"pestilence\" association first appearing in the 20th century. This Horseman is one of confusion amongst theologians as some believe he is representative of divine conquest (and thus a force of good) while others think of him as a representative of unlawful conquest (and thus a force of evil)."
     },
     {
-      "name": "Unicorn",
-      "evolvesTo": "Sraosha",
+      "name": "unicorn",
+      "displayName": "Unicorn",
+      "evolvesTo": "sraosha",
       "primaryElement": "Bless",
       "level": "13",
       "arcana": "Faith",
@@ -5781,7 +5877,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Samarecarm (14 SP, 1 action)",
@@ -5789,18 +5885,19 @@
         },
         {
           "name": "Swift Strike (8 HP, 2 actions)",
-          "description": "You deftly strike at each foe with blinding speed within an area. Make two melee attacks against each creature within a 20-foot sphere centered at a point within range (+4 to hit, 20 feet). For each hit, a creature receives \u000b1d8 + 3 physical damage."
+          "description": "You deftly strike at each foe with blinding speed within an area. Make two melee attacks against each creature within a 20-foot sphere centered at a point within range (+4 to hit, 20 feet). For each hit, a creature receives\n1d8 + 3 physical damage."
         },
         {
           "name": "Kougaon (16 SP, 1 action)",
           "description": "You invoke holy will, and a cascading pillar of light and holy magic erupts from the foe\u2019s space. Make a ranged attack against a creature within range (+4 to hit, 60 feet). On a hit, they receive 4d8 + 4 bless damage."
         }
       ],
-      "background": "An unicorn is a legendary holy creature. Though the modern popular image of the unicorn is sometimes that of a horse differing only in the horn on its forehead, the traditional unicorn also has a billy-goat beard, a lion's tail and cloven hooves; these distinguish it from a horse. It's said to be able to release lightning from its horn. It has a violent temper and all who approach will be swiftly struck down. However, it does not attack virginal humans and will even allow them to ride it. Some say that its horn can neutralize any poison.\n"
+      "background": "An unicorn is a legendary holy creature. Though the modern popular image of the unicorn is sometimes that of a horse differing only in the horn on its forehead, the traditional unicorn also has a billy-goat beard, a lion's tail and cloven hooves; these distinguish it from a horse. It's said to be able to release lightning from its horn. It has a violent temper and all who approach will be swiftly struck down. However, it does not attack virginal humans and will even allow them to ride it. Some say that its horn can neutralize any poison."
     },
     {
-      "name": "Girimehkala",
-      "evolvesTo": "Mara",
+      "name": "girimehkala",
+      "displayName": "Girimehkala",
+      "evolvesTo": "mara",
       "primaryElement": "Physical",
       "level": "14",
       "arcana": "Moon",
@@ -5846,11 +5943,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +2 to hit, range 5 ft., one target. \u000bHit: 1d8 + 4 physical damage."
+          "description": "Melee attack: +2 to hit, range 5 ft., one target.\nHit: 1d8 + 4 physical damage."
         },
         {
           "name": "Deathbound (12 SP, 2 actions)",
-          "description": "Hands of fallen warriors emerge from the soil to grasp and strike at foes. Make two melee attacks against each creature within a 20-foot sphere centered at a point within range (+4 to hit, 20 feet). For each hit, a creature receives \u000b3d8 + 4 physical damage."
+          "description": "Hands of fallen warriors emerge from the soil to grasp and strike at foes. Make two melee attacks against each creature within a 20-foot sphere centered at a point within range (+4 to hit, 20 feet). For each hit, a creature receives\n3d8 + 4 physical damage."
         },
         {
           "name": "Agidyne (16 SP, 1 action)",
@@ -5861,11 +5958,12 @@
           "description": "Darkness and malevolent spirits crush the victim\u2019s will. Choose a creature within range and make a ranged attack against them (+4 to hit, 90 feet). On a hit, if the result of each d6 is 3 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Curse. This Skill provokes a One More if the target is weak to Curse."
         }
       ],
-      "background": "Girimekhala is a large demonic elephant from Sri Lankan mythology. It is said to be the mount of the demonic celestial king Mara, who tried to tempt Buddha so that he could not achieve enlightenment. The Girimekhala's most prominent feature is its one huge eye, which is said to carry a powerful curse. Anyone that looks into its eye will fall ill and cannot be cured.\n"
+      "background": "Girimekhala is a large demonic elephant from Sri Lankan mythology. It is said to be the mount of the demonic celestial king Mara, who tried to tempt Buddha so that he could not achieve enlightenment. The Girimekhala's most prominent feature is its one huge eye, which is said to carry a powerful curse. Anyone that looks into its eye will fall ill and cannot be cured."
     },
     {
-      "name": "Hecatoncheires",
-      "evolvesTo": "Surt",
+      "name": "hecatoncheires",
+      "displayName": "Hecatoncheires",
+      "evolvesTo": "surt",
       "primaryElement": "Physical",
       "level": "14",
       "arcana": "Hanged Man",
@@ -5908,7 +6006,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +2 to hit, range 5 ft., one target. \u000bHit: 1d8 + 4 physical damage."
+          "description": "Melee attack: +2 to hit, range 5 ft., one target.\nHit: 1d8 + 4 physical damage."
         },
         {
           "name": "Gatling Blows (12 HP, 2 actions)",
@@ -5923,10 +6021,11 @@
           "description": "Golden light of obstinance heightens an ally\u2019s ability to deliver punishment. Choose a creature within range (90 feet). For 1 minute, attacks the creature makes score a Critical hit if the result of each d6 is a 5 or higher."
         }
       ],
-      "background": "Known as Hekatonkheires or Hecatonchires, they were giant beings from Greek myth. Having one hundred hands and fifty heads, their father Ouranos found them disgusting and threw them into Tartarus. Eventually, Zeus would free them and they would aid the gods against the Titans.\n"
+      "background": "Known as Hekatonkheires or Hecatonchires, they were giant beings from Greek myth. Having one hundred hands and fifty heads, their father Ouranos found them disgusting and threw them into Tartarus. Eventually, Zeus would free them and they would aid the gods against the Titans."
     },
     {
-      "name": "Kumbhanda",
+      "name": "kumbhanda",
+      "displayName": "Kumbhanda",
       "evolvesTo": null,
       "primaryElement": "Almighty",
       "level": "14",
@@ -5970,26 +6069,27 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 1d6 + 4 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 1d6 + 4 physical damage."
         },
         {
           "name": "Life Leech (10 SP, 1 action)",
-          "description": "You voraciously devour a foe\u2019s life force. Make a ranged attack against a creature within range \u000b(+4 to hit, 30 feet). On a hit, the creature receives 2d8 + 3 almighty damage, and you regain hit points equal to 2d8 + 3."
+          "description": "You voraciously devour a foe\u2019s life force. Make a ranged attack against a creature within range\n(+4 to hit, 30 feet). On a hit, the creature receives 2d8 + 3 almighty damage, and you regain hit points equal to 2d8 + 3."
         },
         {
           "name": "Bloodbath (16 HP, 2 actions)",
-          "description": "Ribbons of dark blades lash out, hacking a field into terrifying ribbons. Make a melee attack against each creature within a 20-foot sphere centered at a point within range (+4 to hit, 20 feet). A creature hit by this attack receives \u000b4d8 + 4 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Fear (see \u201cConditions'')."
+          "description": "Ribbons of dark blades lash out, hacking a field into terrifying ribbons. Make a melee attack against each creature within a 20-foot sphere centered at a point within range (+4 to hit, 20 feet). A creature hit by this attack receives\n4d8 + 4 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Fear (see \u201cConditions'')."
         },
         {
           "name": "Revolution (5 SP, 2 actions)",
           "description": "You spark and heighten the effects of the very air itself, causing mayhem. This Skill affects all creatures within range (hostile or not), including yourself (90 feet). All creatures within range gain the effects of Rebellion."
         }
       ],
-      "background": "Kumbhanda is one of a group of dwarfish, misshapen spirits among the lesser deities of Buddhist mythology. They are known to suck the life out of humans and are servants of the southern member of the Four Heavenly Kings, Zouchouten.\n"
+      "background": "Kumbhanda is one of a group of dwarfish, misshapen spirits among the lesser deities of Buddhist mythology. They are known to suck the life out of humans and are servants of the southern member of the Four Heavenly Kings, Zouchouten."
     },
     {
-      "name": "Kushinada",
-      "evolvesTo": "Okuninushi",
+      "name": "kushinada",
+      "displayName": "Kushinada",
+      "evolvesTo": "okuninushi",
       "primaryElement": "Healing",
       "level": "14",
       "arcana": "Lovers",
@@ -6031,7 +6131,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +2 to hit, range 5 ft., one target. \u000bHit: 1d8 + 4 physical damage."
+          "description": "Melee attack: +2 to hit, range 5 ft., one target.\nHit: 1d8 + 4 physical damage."
         },
         {
           "name": "Mediarama (9 SP, 2 actions)",
@@ -6046,11 +6146,12 @@
           "description": "You remedy the impurities of all your comrades, cleansing the field of malady. Choose up to six creatures within range (60 feet). Each of those creatures recover from all Conditions."
         }
       ],
-      "background": "In Japanese mythology, Kushinada-Hime (\u6adb\u540d\u7530\u6bd4\u58f2 in Kojiki or \u5947\u7a32\u7530\u59eb in Nihonshoki), or simply Kushinada, was the daughter of two lesser gods of the Kunitsu, Ashinazuchi and Tenazuchi. She would later become the wife of the god of storms, Susano-o.\n According to the Shinto legend, after Susano-o was expelled from Heaven, he encountered two weeping earthly deities near a river in the Izumo Province. After asking why they wept, they explained that they had to give the Orochi one of their daughters every year to prevent his violent rampage, and now they must sacrifice their eighth and final daughter, Kushinada.\n"
+      "background": "In Japanese mythology, Kushinada-Hime (\u6adb\u540d\u7530\u6bd4\u58f2 in Kojiki or \u5947\u7a32\u7530\u59eb in Nihonshoki), or simply Kushinada, was the daughter of two lesser gods of the Kunitsu, Ashinazuchi and Tenazuchi. She would later become the wife of the god of storms, Susano-o.\n\nAccording to the Shinto legend, after Susano-o was expelled from Heaven, he encountered two weeping earthly deities near a river in the Izumo Province. After asking why they wept, they explained that they had to give the Orochi one of their daughters every year to prevent his violent rampage, and now they must sacrifice their eighth and final daughter, Kushinada."
     },
     {
-      "name": "Ose",
-      "evolvesTo": "Forneus",
+      "name": "ose",
+      "displayName": "Ose",
+      "evolvesTo": "forneus",
       "primaryElement": "Physical",
       "level": "14",
       "arcana": "Fool",
@@ -6088,13 +6189,13 @@
       "traits": [
         {
           "name": "Retaliating Body",
-          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n \u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n \u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled."
+          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n\u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n\u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +2 to hit, range 5 ft., one target. \u000bHit: 1d8 + 4 physical damage."
+          "description": "Melee attack: +2 to hit, range 5 ft., one target.\nHit: 1d8 + 4 physical damage."
         },
         {
           "name": "Oni-Kagura (12 HP, 2 actions)",
@@ -6109,11 +6210,12 @@
           "description": "A rallying cry and magic reinforcement strengthens your entire group. Choose up to six creatures within range (90 feet). Those creatures gain the effects of Tarukaja."
         }
       ],
-      "background": "Ose, also known as Os\u00e9, Oze, Oso or Voso, is the 57th demonic spirit of Ars Goetia and a great president of Hell. He first appears as a leopard, but after some time will take the form of a man. He gives skill in all liberal sciences and true answers concerning divine and secret things. He can change any man into any shape the exorcist may desire, and the one that is changed will not know it.\n"
+      "background": "Ose, also known as Os\u00e9, Oze, Oso or Voso, is the 57th demonic spirit of Ars Goetia and a great president of Hell. He first appears as a leopard, but after some time will take the form of a man. He gives skill in all liberal sciences and true answers concerning divine and secret things. He can change any man into any shape the exorcist may desire, and the one that is changed will not know it."
     },
     {
-      "name": "Power",
-      "evolvesTo": "Dominion",
+      "name": "power",
+      "displayName": "Power",
+      "evolvesTo": "dominion",
       "primaryElement": "Bless",
       "level": "14",
       "arcana": "Justice",
@@ -6157,7 +6259,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 1d6 + 4 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 1d6 + 4 physical damage."
         },
         {
           "name": "Hamaon (12 SP, 1 action)",
@@ -6172,11 +6274,12 @@
           "description": "You accelerate each of your allies to rapid speeds. Choose up to six creatures within range (90 feet). Those creatures gain the effects of Sukukaja."
         }
       ],
-      "background": "Powers, also known as Authorities, are the sixth of the nine orders of angels. It is said that they were the first order to be created. The Powers are the bearers of conscience and the keepers of history. Their duty is to oversee the distribution of power among humankind, hence their name. They are academically driven and are concerned with ideology, philosophy, theology, religion and documents pertaining to those studies. Powers are the brain trusts; a group of experts who serve as advisers and policy planners. They are also the warrior angels created to be completely loyal to God. Some believe that no Power has ever fallen from grace, but another theory states that Satan was the Chief of the Powers before he fell. Their duty is to oversee the distribution of power among humankind, hence their name.\n"
+      "background": "Powers, also known as Authorities, are the sixth of the nine orders of angels. It is said that they were the first order to be created. The Powers are the bearers of conscience and the keepers of history. Their duty is to oversee the distribution of power among humankind, hence their name. They are academically driven and are concerned with ideology, philosophy, theology, religion and documents pertaining to those studies. Powers are the brain trusts; a group of experts who serve as advisers and policy planners. They are also the warrior angels created to be completely loyal to God. Some believe that no Power has ever fallen from grace, but another theory states that Satan was the Chief of the Powers before he fell. Their duty is to oversee the distribution of power among humankind, hence their name."
     },
     {
-      "name": "Queen Mab",
-      "evolvesTo": "Titiana",
+      "name": "queen-mab",
+      "displayName": "Queen Mab",
+      "evolvesTo": "titiana",
       "primaryElement": "Electric",
       "level": "14",
       "arcana": "Magician",
@@ -6213,17 +6316,17 @@
       "traits": [
         {
           "name": "Static Electricity",
-          "description": "An overabundance of electrical power primes a foe for paralysis. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with Shock (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "An overabundance of electrical power primes a foe for paralysis. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with Shock (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +7 to hit, range 5 ft., one target. \u000bHit: 1d4 + 2 physical damage."
+          "description": "Melee attack: +7 to hit, range 5 ft., one target.\nHit: 1d4 + 2 physical damage."
         },
         {
           "name": "Ziodyne (16 SP, 1 action)",
-          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+5 to hit, 30 feet). On a hit, they receive \u000b3d8 + 4 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
+          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+5 to hit, 30 feet). On a hit, they receive\n3d8 + 4 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
         },
         {
           "name": "Agidyne (16 SP, 1 action)",
@@ -6234,10 +6337,11 @@
           "description": "You gather and focus your mind's eye, delivering an absolute force of will. The next damage roll you make for an attack that deals Fire, Ice, Electric, Wind, Psychic, Nuke, Bless, Curse, or Almighty damage within the next 10 minutes is doubled."
         }
       ],
-      "background": "Mab, also known as Medb or Meive, is the queen of Connacht. Famous for her capricious nature and her many lovers, she wages many wars for the sake of her continued glory. The Cattle Raid of Cooley makes her cross paths with her archenemy Cu Chulainn, who shamed her numerous times by slaying her pets, warriors and handmaidens. She is the enemy (and former wife) of Conchobar mac Nessa, king of Ulster, and is best known for starting the T\u00e1in B\u00f3 C\u00faailnge (\"The Cattle Raid of Cooley\") to steal Ulster's prize stud bull Donn C\u00faailnge.\n"
+      "background": "Mab, also known as Medb or Meive, is the queen of Connacht. Famous for her capricious nature and her many lovers, she wages many wars for the sake of her continued glory. The Cattle Raid of Cooley makes her cross paths with her archenemy Cu Chulainn, who shamed her numerous times by slaying her pets, warriors and handmaidens. She is the enemy (and former wife) of Conchobar mac Nessa, king of Ulster, and is best known for starting the T\u00e1in B\u00f3 C\u00faailnge (\"The Cattle Raid of Cooley\") to steal Ulster's prize stud bull Donn C\u00faailnge."
     },
     {
-      "name": "Red Rider",
+      "name": "red-rider",
+      "displayName": "Red Rider",
       "evolvesTo": null,
       "primaryElement": "Psychic",
       "level": "14",
@@ -6273,13 +6377,13 @@
       "traits": [
         {
           "name": "Hollow Jester",
-          "description": "You seek out the weak-willed and the ailing pack. You gain the following benefits:\n \u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n \u2022 You may add half your character level (min 1) to the damage roll of any attack against a target afflicted with a Condition. You may add this bonus multiple times, once for each Condition the target is inflicted with."
+          "description": "You seek out the weak-willed and the ailing pack. You gain the following benefits:\n\u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n\u2022 You may add half your character level (min 1) to the damage roll of any attack against a target afflicted with a Condition. You may add this bonus multiple times, once for each Condition the target is inflicted with."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Psiodyne (16 SP, 1 action)",
@@ -6294,11 +6398,12 @@
           "description": "Abyssal energes infused with your attack blast the foe from above. Make a melee attack against a creature within range (+4 to hit, 5 feet). On a hit, the creature receives 2d10 + 3 physical damage. If the result of each d6 in the attack roll is 4 or higher, the target is afflicted with Despair (see \u201cConditions\u201d)."
         }
       ],
-      "background": "The Red Rider, or Red Horseman, is the second of the Four Horsemen of the Apocalypse, also named War. He represents war, and his horse is colored \"fiery\" red and bearing a sword of war. Unlike Conquest, the Red Horseman of War specializes in waging war between nations and people rather than internal strife.\n"
+      "background": "The Red Rider, or Red Horseman, is the second of the Four Horsemen of the Apocalypse, also named War. He represents war, and his horse is colored \"fiery\" red and bearing a sword of war. Unlike Conquest, the Red Horseman of War specializes in waging war between nations and people rather than internal strife."
     },
     {
-      "name": "Yurlungur",
-      "evolvesTo": "Quetzacoatl",
+      "name": "yurlungur",
+      "displayName": "Yurlungur",
+      "evolvesTo": "quetzacoatl",
       "primaryElement": "Support",
       "level": "14",
       "arcana": "Sun",
@@ -6335,13 +6440,13 @@
       "traits": [
         {
           "name": "Majestic Presence",
-          "description": "When you have the initiative, you can unleash a storm of gunfire on foes, in addition to your cheap shots. You gain the following benefits:\n \u2022 Whenever a creature would regain hit points from a Skill within 60 feet, you may add a 2d8 bonus to the amount regained. This bonus is increased by 2d8 at 15th level (4d8).\n \u2022 Whenever a creature within 60 feet of you uses a Healing Skill, you may roll 1d4. On a 4, the spell point cost of that Skill is halved for that use, to a minimum of 1."
+          "description": "When you have the initiative, you can unleash a storm of gunfire on foes, in addition to your cheap shots. You gain the following benefits:\n\u2022 Whenever a creature would regain hit points from a Skill within 60 feet, you may add a 2d8 bonus to the amount regained. This bonus is increased by 2d8 at 15th level (4d8).\n\u2022 Whenever a creature within 60 feet of you uses a Healing Skill, you may roll 1d4. On a 4, the spell point cost of that Skill is halved for that use, to a minimum of 1."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 1d6 + 3 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 1d6 + 3 physical damage."
         },
         {
           "name": "Revolution (5 SP, 2 actions)",
@@ -6353,13 +6458,14 @@
         },
         {
           "name": "Brain Jack (10 SP, 2 actions)",
-          "description": "You\u2019re not asking anymore. You use magic to directly weave into the hearts of foes, seizing control of the field. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range \u000b(+4 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Brainwash (see \u201cConditions\u201d)."
+          "description": "You\u2019re not asking anymore. You use magic to directly weave into the hearts of foes, seizing control of the field. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range\n(+4 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Brainwash (see \u201cConditions\u201d)."
         }
       ],
       "background": "In aboriginal Australian mythology, the Yurlungur is a great copper snake that is said to bring the rains and thus incite the renewal of life. It is commonly known as the Rainbow Serpent or the Rainbow Snake, because the water where it lives shines like a rainbow. It was believed that if colored light was seen inside a well (likely caused by light reflection) then the Yurlungur was within."
     },
     {
-      "name": "Ananta",
+      "name": "ananta",
+      "displayName": "Ananta",
       "evolvesTo": null,
       "primaryElement": "Nuke",
       "level": "15",
@@ -6401,7 +6507,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 1d8 + 2 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 1d8 + 2 physical damage."
         },
         {
           "name": "Freidyne (8 SP, 1 action)",
@@ -6416,10 +6522,11 @@
           "description": "You coordinate the defense of your allies, covering flanks and shielding them from danger. Choose up to six creatures within range. Those creatures gain the effects of Rakukaja."
         }
       ],
-      "background": "Shesha, also known as Ananta, is the king of all nagas according to Hindu mythology and one of the primal beings of creation. He is sometimes called Ananta Shesha which means \"Endless Shesha\" as he is said to hold all the planets in the universe on his hoods. He is usually depicted as a massive coiled serpent with as many as five to one thousand heads, sometimes wearing an ornate crown on each head. The heads are not only venomous but spew fire as well. He was born from the mouth of the sleeping Balarama (sun god's brother) where he devoured all but Balarama's head.\n"
+      "background": "Shesha, also known as Ananta, is the king of all nagas according to Hindu mythology and one of the primal beings of creation. He is sometimes called Ananta Shesha which means \"Endless Shesha\" as he is said to hold all the planets in the universe on his hoods. He is usually depicted as a massive coiled serpent with as many as five to one thousand heads, sometimes wearing an ornate crown on each head. The heads are not only venomous but spew fire as well. He was born from the mouth of the sleeping Balarama (sun god's brother) where he devoured all but Balarama's head."
     },
     {
-      "name": "Athena",
+      "name": "athena",
+      "displayName": "Athena",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "15",
@@ -6457,13 +6564,13 @@
       "traits": [
         {
           "name": "Grace of the Olive",
-          "description": "The opportunity will not be lost by your hand, as you execute with splendid grace and efficacy. You gain the following benefits:\n \u2022 The Hit Point and Spell Point cost of Skills used by actions granted by a One More! are reduced to 0."
+          "description": "The opportunity will not be lost by your hand, as you execute with splendid grace and efficacy. You gain the following benefits:\n\u2022 The Hit Point and Spell Point cost of Skills used by actions granted by a One More! are reduced to 0."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 1d6 + 4 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 1d6 + 4 physical damage."
         },
         {
           "name": "Akashic Arts (17 HP, 2 actions)",
@@ -6478,11 +6585,12 @@
           "description": "A cascade of verdant light basks an ally in a healing glow, healing their most grievous injury. Choose a creature within range (90 feet). That creature regains 6d8 + 6 hit points."
         }
       ],
-      "background": "Athena is the Greek goddess of wisdom, courage, inspiration, civilization, philosophy, justice, law, mathematics, strength, arts, crafts, weaving, skill and reason who sprung from Zeus' forehead fully armored after he swallowed her mother, Metis. She represents just decisions and strategic warfare and is the only goddess allowed to carry Zeus' thunderbolts. She led battles as the disciplined, strategic side of war, in contrast to her brother Ares, the patron of violence, bloodlust and slaughter.\n"
+      "background": "Athena is the Greek goddess of wisdom, courage, inspiration, civilization, philosophy, justice, law, mathematics, strength, arts, crafts, weaving, skill and reason who sprung from Zeus' forehead fully armored after he swallowed her mother, Metis. She represents just decisions and strategic warfare and is the only goddess allowed to carry Zeus' thunderbolts. She led battles as the disciplined, strategic side of war, in contrast to her brother Ares, the patron of violence, bloodlust and slaughter."
     },
     {
-      "name": "Byakko",
-      "evolvesTo": "Barong",
+      "name": "byakko",
+      "displayName": "Byakko",
+      "evolvesTo": "barong",
       "primaryElement": "Ice",
       "level": "15",
       "arcana": "Temperance",
@@ -6520,13 +6628,13 @@
       "traits": [
         {
           "name": "Retaliating Body",
-          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n \u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n \u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled."
+          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n\u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n\u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 1d6 + 4 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 1d6 + 4 physical damage."
         },
         {
           "name": "Bufudyne (16 SP, 1 action)",
@@ -6538,14 +6646,15 @@
         },
         {
           "name": "Swift Strike (8 HP, 2 actions)",
-          "description": "You deftly strike at each foe with blinding speed within an area. Make two melee attacks against each creature within a 20-foot sphere centered at a point within range (+4 to hit, 20 feet). For each hit, a creature receives \u000b1d8 + 4 physical damage"
+          "description": "You deftly strike at each foe with blinding speed within an area. Make two melee attacks against each creature within a 20-foot sphere centered at a point within range (+4 to hit, 20 feet). For each hit, a creature receives\n1d8 + 4 physical damage"
         }
       ],
-      "background": "The Bai Hu (\u767d\u864e), literally the White Tiger, is one of the Four Symbols of the Chinese Constellation (Si Xiang) along with Qing Long, Zhu Que and Xuan Wu. It represents the western part of the 28 star mansions, the autumn season and the element of \"metal\" (\"wind\" in the Japanese system). It is known as Byakko in Japan and Baekho in Korea.\n"
+      "background": "The Bai Hu (\u767d\u864e), literally the White Tiger, is one of the Four Symbols of the Chinese Constellation (Si Xiang) along with Qing Long, Zhu Que and Xuan Wu. It represents the western part of the 28 star mansions, the autumn season and the element of \"metal\" (\"wind\" in the Japanese system). It is known as Byakko in Japan and Baekho in Korea."
     },
     {
-      "name": "Fortuna",
-      "evolvesTo": "Lakshmi",
+      "name": "fortuna",
+      "displayName": "Fortuna",
+      "evolvesTo": "lakshmi",
       "primaryElement": "Wind",
       "level": "15",
       "arcana": "Fortune",
@@ -6587,11 +6696,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 1d8 + 2 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 1d8 + 2 physical damage."
         },
         {
           "name": "Garudyne (7 SP, 1 action)",
-          "description": "A maelstrom wraps around a target, buffeting them into oblivion. Make a ranged attack against a creature within range (+4 to hit, 90 feet). On a hit, they receive \u000b3d8 + 4 wind damage."
+          "description": "A maelstrom wraps around a target, buffeting them into oblivion. Make a ranged attack against a creature within range (+4 to hit, 90 feet). On a hit, they receive\n3d8 + 4 wind damage."
         },
         {
           "name": "Masukukaja (24 SP, 2 actions)",
@@ -6602,10 +6711,11 @@
           "description": "Divine strength fills your allies, warding them from peril. Choose up to six creatures within range (90 feet). The next time, within the next 10 minutes, they would instantly be reduced to 0 hit points from a Hama or Mudo type Skill, or from Door of Hades, the effect is prevented completely."
         }
       ],
-      "background": "Fortuna, also known as Lady Fortune, is the goddess of fortune, chance, and luck in Roman mythology, daughter of Jupiter and Venus. She can be represented as veiled or blind. She is believed to have originally been a goddess of blessing and fertility, mainly being worshiped by mothers. She was also treated as the personification of Luck. She is the Roman counterpart of the Greek minor goddess Tyche.\n"
+      "background": "Fortuna, also known as Lady Fortune, is the goddess of fortune, chance, and luck in Roman mythology, daughter of Jupiter and Venus. She can be represented as veiled or blind. She is believed to have originally been a goddess of blessing and fertility, mainly being worshiped by mothers. She was also treated as the personification of Luck. She is the Roman counterpart of the Greek minor goddess Tyche."
     },
     {
-      "name": "Magatsu-Izanagi",
+      "name": "magatsu-izanagi",
+      "displayName": "Magatsu-Izanagi",
       "evolvesTo": null,
       "primaryElement": "Curse",
       "level": "15",
@@ -6644,13 +6754,13 @@
       "traits": [
         {
           "name": "Hollow Jester",
-          "description": "You seek out the weak-willed and the ailing pack. You gain the following benefits:\n \u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n \u2022 You may add half your character level (min 1) to the damage roll of any attack against a target afflicted with a Condition. You may add this bonus multiple times, once for each Condition the target is inflicted with."
+          "description": "You seek out the weak-willed and the ailing pack. You gain the following benefits:\n\u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n\u2022 You may add half your character level (min 1) to the damage roll of any attack against a target afflicted with a Condition. You may add this bonus multiple times, once for each Condition the target is inflicted with."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 1d6 + 4 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 1d6 + 4 physical damage."
         },
         {
           "name": "Magatsu Mandala (32 SP, 2 actions)",
@@ -6658,17 +6768,18 @@
         },
         {
           "name": "Bloodbath (16 HP, 2 actions)",
-          "description": "Ribbons of dark blades lash out, hacking a field into terrifying ribbons. Make a melee attack against each creature within a 20-foot sphere centered at a point within range (+4 to hit, 20 feet). A creature hit by this attack receives \u000b4d8 + 4 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Fear (see \u201cConditions'')."
+          "description": "Ribbons of dark blades lash out, hacking a field into terrifying ribbons. Make a melee attack against each creature within a 20-foot sphere centered at a point within range (+4 to hit, 20 feet). A creature hit by this attack receives\n4d8 + 4 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Fear (see \u201cConditions'')."
         },
         {
           "name": "Ghastly Wail (16 SP, 2 actions)",
           "description": "Dark energy pours from your mouth, manifesting in a banshee\u2019s cry that severs the souls of the weak-willed. This Skill affects all creatures within range, including yourself and allies (30 feet). Each creature afflicted by the Fear condition (see \u201cConditions\u201d) within range is reduced to 0 hit points immediately."
         }
       ],
-      "background": "Magatsu-Izanagi (\u798d\u6d25\u4f0a\u5f09\u8afe) means \"Calamity Izanagi.\" This refers to Izanagi's state before he washed away the filth from Yomotsu Hirasaka in a failed mission to retrieve his late consort, Izanami.\n Magatsu-Izanagi also represents \"Emptiness.\""
+      "background": "Magatsu-Izanagi (\u798d\u6d25\u4f0a\u5f09\u8afe) means \"Calamity Izanagi.\" This refers to Izanagi's state before he washed away the filth from Yomotsu Hirasaka in a failed mission to retrieve his late consort, Izanami.\n\nMagatsu-Izanagi also represents \"Emptiness.\""
     },
     {
-      "name": "Pazuzu",
+      "name": "pazuzu",
+      "displayName": "Pazuzu",
       "evolvesTo": null,
       "primaryElement": "Curse",
       "level": "15",
@@ -6712,7 +6823,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 1d4 + 3 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 1d4 + 3 physical damage."
         },
         {
           "name": "Eigaon (8 SP, 1 action)",
@@ -6727,11 +6838,12 @@
           "description": "Your wickedness is magically enhanced, sending waves of chills through all who witness. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range (+4 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Fear (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Pazuzu is an apotropaic being from Mesopotamian mythology, first attested in the late Bronze Age and described as a king of demons, as well as a personification of the west wind. His origin is uncertain, but various connections with personifications of winds serving gods as messengers, Humbaba and pessu (a creature derived from Egyptian god Bes) have been proposed by researchers.\n"
+      "background": "Pazuzu is an apotropaic being from Mesopotamian mythology, first attested in the late Bronze Age and described as a king of demons, as well as a personification of the west wind. His origin is uncertain, but various connections with personifications of winds serving gods as messengers, Humbaba and pessu (a creature derived from Egyptian god Bes) have been proposed by researchers."
     },
     {
-      "name": "Valkyrie",
-      "evolvesTo": "Scathach",
+      "name": "valkyrie",
+      "displayName": "Valkyrie",
+      "evolvesTo": "scathach",
       "primaryElement": "Physical",
       "level": "15",
       "arcana": "Strength",
@@ -6770,13 +6882,13 @@
       "traits": [
         {
           "name": "Attack Master",
-          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action."
+          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 1d6 + 4 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 1d6 + 4 physical damage."
         },
         {
           "name": "Rising Slash (9 HP, 1 action)",
@@ -6784,18 +6896,19 @@
         },
         {
           "name": "Deathbound (12 SP, 2 actions)",
-          "description": "Hands of fallen warriors emerge from the soil to grasp and strike at foes. Make two melee attacks against each creature within a 20-foot sphere centered at a point within range (+3 to hit, 20 feet). For each hit, a creature receives \u000b2d8 + 4 physical damage."
+          "description": "Hands of fallen warriors emerge from the soil to grasp and strike at foes. Make two melee attacks against each creature within a 20-foot sphere centered at a point within range (+3 to hit, 20 feet). For each hit, a creature receives\n2d8 + 4 physical damage."
         },
         {
           "name": "Matarukaja (24 SP, 2 actions)",
           "description": "A rallying cry and magic reinforcement strengthens your entire group. Choose up to six creatures within range (90 feet). Those creatures gain the effects of Tarukaja."
         }
       ],
-      "background": "A Valkyrie (from Old Norse valkyrja \"chooser of the slain\") is one of a host of female figures that appear to the dead in Norse Mythology and decide who will die in battle. The valkyries bring their chosen to the afterlife hall of the slain, Valhalla, ruled over by the god Odin, where the deceased warriors become einherjar. There, when the einherjar are not preparing for the events of Ragnar\u00f6k, the valkyries bear them mead. Valkyries also appear as lovers of heroes and other mortals, where they are sometimes described as the daughters of royalty, sometimes accompanied by ravens, and sometimes connected to swans.\n"
+      "background": "A Valkyrie (from Old Norse valkyrja \"chooser of the slain\") is one of a host of female figures that appear to the dead in Norse Mythology and decide who will die in battle. The valkyries bring their chosen to the afterlife hall of the slain, Valhalla, ruled over by the god Odin, where the deceased warriors become einherjar. There, when the einherjar are not preparing for the events of Ragnar\u00f6k, the valkyries bear them mead. Valkyries also appear as lovers of heroes and other mortals, where they are sometimes described as the daughters of royalty, sometimes accompanied by ravens, and sometimes connected to swans."
     },
     {
-      "name": "Bugs",
-      "evolvesTo": "Macabre",
+      "name": "bugs",
+      "displayName": "Bugs",
+      "evolvesTo": "macabre",
       "primaryElement": "Psychic",
       "level": "16",
       "arcana": "Fool",
@@ -6836,13 +6949,13 @@
         },
         {
           "name": "Attack Master",
-          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action . "
+          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action . "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +6 to hit, range 5 ft., one target. \u000bHit: 2d4 + 4 physical damage."
+          "description": "Melee attack: +6 to hit, range 5 ft., one target.\nHit: 2d4 + 4 physical damage."
         },
         {
           "name": "Psiodyne (16 SP, 1 action)",
@@ -6850,18 +6963,19 @@
         },
         {
           "name": "Triple Down (9 HP, 2 actions)",
-          "description": "A trifecta of cunning blows knock a foe asunder. Make three melee attacks against each creature within a 10-foot sphere centered at a point within range \u000b(+4 to hit, 10 feet). For each hit, the creature receives \u000b2d10 + 4 gun damage."
+          "description": "A trifecta of cunning blows knock a foe asunder. Make three melee attacks against each creature within a 10-foot sphere centered at a point within range\n(+4 to hit, 10 feet). For each hit, the creature receives\n2d10 + 4 gun damage."
         },
         {
           "name": "Masukunda (24 SP, 2 actions)",
           "description": "You bind and slow a group of enemies, allowing you to act faster than them. Choose up to six creatures within range. Those creatures gain the effects of Sukunda."
         }
       ],
-      "background": "Bugbear, or simply Bugs, is a type of Hobgoblin that is comparable to the Boogeyman (Bugaboo) in folklore. In lore, the Bugbear was depicted as a creepy bear that lurked in the woods to scare children. Bugbear was used to frighten children into behaving or obeying their parents.\n Its name is derived from the Celtic word bug which means \"evil spirit\" or \"goblin.\"\n"
+      "background": "Bugbear, or simply Bugs, is a type of Hobgoblin that is comparable to the Boogeyman (Bugaboo) in folklore. In lore, the Bugbear was depicted as a creepy bear that lurked in the woods to scare children. Bugbear was used to frighten children into behaving or obeying their parents.\n\nIts name is derived from the Celtic word bug which means \"evil spirit\" or \"goblin.\""
     },
     {
-      "name": "Dakini",
-      "evolvesTo": "Kali",
+      "name": "dakini",
+      "displayName": "Dakini",
+      "evolvesTo": "kali",
       "primaryElement": "Physical",
       "level": "16",
       "arcana": "Empress",
@@ -6906,7 +7020,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 2d6 + 4 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 2d6 + 4 physical damage."
         },
         {
           "name": "Bad Beat (12 HP, 2 actions)",
@@ -6921,11 +7035,12 @@
           "description": "You begin amassing your strength and stamina, coalescing into an ultimate strike. The next damage roll you make for an attack that deals Physical or Gun damage within the next 10 minutes is doubled."
         }
       ],
-      "background": "A dakini is a tantric deity described as an embodiment of enlightened energy that resembles a female. In each of her various guises, she serves as each of the Three Roots. She may be a human guru, a yidam or she may be a protector.\n In Japanese Buddhism, dakini are recognized as fox spirits and are also recognized as a goddess called Dakiniten, who is associated with Inari and Daikoku-ten.\n"
+      "background": "A dakini is a tantric deity described as an embodiment of enlightened energy that resembles a female. In each of her various guises, she serves as each of the Three Roots. She may be a human guru, a yidam or she may be a protector.\n\nIn Japanese Buddhism, dakini are recognized as fox spirits and are also recognized as a goddess called Dakiniten, who is associated with Inari and Daikoku-ten."
     },
     {
-      "name": "Horus",
-      "evolvesTo": "Seth",
+      "name": "horus",
+      "displayName": "Horus",
+      "evolvesTo": "seth",
       "primaryElement": "Bless",
       "level": "16",
       "arcana": "Sun",
@@ -6972,7 +7087,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 2d4 + 4 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 2d4 + 4 physical damage."
         },
         {
           "name": "Hamaon (12 SP, 1 action)",
@@ -6990,8 +7105,9 @@
       "background": "Often identified with the sun, Horus (also known as Her, Heru, Hor or Har) was known as one of the most powerful gods of the Egyptian pantheon. He is the falcon-headed sun god and the prince of Egypt. Horus was occasionally shown in art as a naked boy with a finger in his mouth sitting on a lotus with his mother. In the form of a youth, Horus was referred to as Neferhor, Nephoros or Nopheros (literally known as Good Horus). He is the son of the god Osiris and Isis, seeks revenge for his father's death at the hands of the god Set."
     },
     {
-      "name": "Koumokuten",
-      "evolvesTo": "Bishamonten",
+      "name": "koumokuten",
+      "displayName": "Koumokuten",
+      "evolvesTo": "bishamonten",
       "primaryElement": "Physical",
       "level": "16",
       "arcana": "Hermit",
@@ -7037,11 +7153,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 2d4 + 4 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 2d4 + 4 physical damage."
         },
         {
           "name": "Rising Slash (13 HP, 1 action)",
-          "description": "A horizontal slash with blinding speed strikes the opponent with godly precision and severing force. Make a melee attack against a creature within range \u000b(+3 to hit, 10 feet). On a hit, the creature receives 6d10 + 4 physical damage. If this Skill is used with an action granted by a Baton Pass, the damage dealt is doubled."
+          "description": "A horizontal slash with blinding speed strikes the opponent with godly precision and severing force. Make a melee attack against a creature within range\n(+3 to hit, 10 feet). On a hit, the creature receives 6d10 + 4 physical damage. If this Skill is used with an action granted by a Baton Pass, the damage dealt is doubled."
         },
         {
           "name": "Revolution (5 SP, 2 actions)",
@@ -7052,10 +7168,11 @@
           "description": "A rallying cry and magic reinforcement strengthens your entire group. Choose up to six creatures within range (90 feet). Those creatures gain the effects of Tarukaja."
         }
       ],
-      "background": "Koumokuten (\u5e83\u76ee\u5929), also known as Vir\u016bp\u0101k\u1e63a in Sanskrit, is the guardian deity that protects the west of Buddha's realm. His name means \"vast/all-seeing eyes.\" He has red skin and leads the troop of Nagas, the lesser snake-man gods. Some statues have him carry a Pasha which works similar to a lasso for capturing running target. Many of his attributes are very similar to Varuna, who happens to be the guardian of the west in Lokapala.\n"
+      "background": "Koumokuten (\u5e83\u76ee\u5929), also known as Vir\u016bp\u0101k\u1e63a in Sanskrit, is the guardian deity that protects the west of Buddha's realm. His name means \"vast/all-seeing eyes.\" He has red skin and leads the troop of Nagas, the lesser snake-man gods. Some statues have him carry a Pasha which works similar to a lasso for capturing running target. Many of his attributes are very similar to Varuna, who happens to be the guardian of the west in Lokapala."
     },
     {
-      "name": "Narcissus",
+      "name": "narcissus",
+      "displayName": "Narcissus",
       "evolvesTo": null,
       "primaryElement": "Healing",
       "level": "16",
@@ -7094,17 +7211,17 @@
       "traits": [
         {
           "name": "Foul Stench",
-          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         },
         {
           "name": "Majestic Presence",
-          "description": "When you have the initiative, you can unleash a storm of gunfire on foes, in addition to your cheap shots. You gain the following benefits:\n \u2022 Whenever a creature would regain hit points from a Skill within 60 feet, you may add a 2d8 bonus to the amount regained. This bonus is increased by 2d8 at 15th level (4d8).\n \u2022 Whenever a creature within 60 feet of you uses a Healing Skill, you may roll 1d4. On a 4, the spell point cost of that Skill is halved for that use, to a minimum of 1 . "
+          "description": "When you have the initiative, you can unleash a storm of gunfire on foes, in addition to your cheap shots. You gain the following benefits:\n\u2022 Whenever a creature would regain hit points from a Skill within 60 feet, you may add a 2d8 bonus to the amount regained. This bonus is increased by 2d8 at 15th level (4d8).\n\u2022 Whenever a creature within 60 feet of you uses a Healing Skill, you may roll 1d4. On a 4, the spell point cost of that Skill is halved for that use, to a minimum of 1 . "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +7 to hit, range 5 ft., one target. \u000bHit: 2d4 + 2 physical damage."
+          "description": "Melee attack: +7 to hit, range 5 ft., one target.\nHit: 2d4 + 2 physical damage."
         },
         {
           "name": "Dazzler (5 SP, 1 action)",
@@ -7116,14 +7233,15 @@
         },
         {
           "name": "Energy Drop (6 SP, 1 action)",
-          "description": "A stimulating remedy opens one\u2019s eyes against emotional malady. Choose a creature within range \u000b(60 feet). That creature recovers from Confuse, Fear, Despair, Rage, and Brainwash (see \u201cConditions\u201d)."
+          "description": "A stimulating remedy opens one\u2019s eyes against emotional malady. Choose a creature within range\n(60 feet). That creature recovers from Confuse, Fear, Despair, Rage, and Brainwash (see \u201cConditions\u201d)."
         }
       ],
       "background": "Narcissus (Greek: \u039d\u03ac\u03c1\u03ba\u03b9\u03c3\u03c3\u03bf\u03c2) was a strong and beautiful boy of Greek mythology. He is also known for his cruel disposition; he rejected the love of the youths, boy and girl, who adored him. His final act of rejection led to him being cursed by the deity of retribution, Nemesis. He fell in love with his own reflection in the water, which inadvertently led to his death. Accounts vary on the circumstances that brought Narcissus to his watery death, and even the cause of his death differs; he either drowned himself trying to embrace the image, starved to death or killed himself for being unable to accept this love. Either way, a flower grew from the spot he died, which was named the \"narcissus.\""
     },
     {
-      "name": "Rangda",
-      "evolvesTo": "Shiva",
+      "name": "rangda",
+      "displayName": "Rangda",
+      "evolvesTo": "shiva",
       "primaryElement": "Curse",
       "level": "16",
       "arcana": "Magician",
@@ -7167,13 +7285,13 @@
         },
         {
           "name": "Retaliating Body",
-          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n \u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n \u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled . "
+          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n\u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n\u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled . "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 2d6 + 3 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 2d6 + 3 physical damage."
         },
         {
           "name": "Eigaon (8 SP, 1 action)",
@@ -7181,18 +7299,19 @@
         },
         {
           "name": "Bloodbath (16 HP, 2 actions)",
-          "description": "Ribbons of dark blades lash out, hacking a field into terrifying ribbons. Make a melee attack against each creature within a 20-foot sphere centered at a point within range (+4 to hit, 20 feet). A creature hit by this attack receives \u000b4d8 + 3 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Fear (see \u201cConditions'')."
+          "description": "Ribbons of dark blades lash out, hacking a field into terrifying ribbons. Make a melee attack against each creature within a 20-foot sphere centered at a point within range (+4 to hit, 20 feet). A creature hit by this attack receives\n4d8 + 3 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Fear (see \u201cConditions'')."
         },
         {
           "name": "Matarunda (24 SP, 2 actions)",
           "description": "You unleash a diminishing wave that inhibits foes. Choose up to six creatures within range (90 feet). Those creatures gain the effects of Tarunda."
         }
       ],
-      "background": "Rangda is the demon queen of the leyaks in Bali, according to traditional Balinese mythology. Terrifying to behold, the child-eating Rangda leads an army of evil witches against the leader of the forces of good, Barong.\n"
+      "background": "Rangda is the demon queen of the leyaks in Bali, according to traditional Balinese mythology. Terrifying to behold, the child-eating Rangda leads an army of evil witches against the leader of the forces of good, Barong."
     },
     {
-      "name": "Barong",
-      "evolvesTo": "Shiva",
+      "name": "barong",
+      "displayName": "Barong",
+      "evolvesTo": "shiva",
       "primaryElement": "Electric",
       "level": "17",
       "arcana": "Emperor",
@@ -7241,11 +7360,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 2d4 + 3 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 2d4 + 3 physical damage."
         },
         {
           "name": "Ziodyne (16 SP, 1 action)",
-          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+5 to hit, 30 feet). On a hit, they receive \u000b6d8 + 4 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
+          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+5 to hit, 30 feet). On a hit, they receive\n6d8 + 4 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
         },
         {
           "name": "Kougaon (8 SP, 1 action)",
@@ -7256,10 +7375,11 @@
           "description": "A magical decree of war creates a tension, a pressure to enter a frenzy  within the battlefield. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range (+5 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Rage (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Barong is the protector of mankind that represents the forces of good in Indonesian lore. It uses its charms and magic to defend villagers against the deathly black magic of the witch Rangda. He is a guardian spirit that is most commonly seen in the form of a lion, although each region within Bali has its own version of Barong, the others being a dragon, boar or a tiger. Barong is animated by the brother spirit Banas Pati Rajah to do battle with Rangda in order to restore the balance between good and evil. However, after Rangda is killed, she is eventually resurrected, and Barong must do battle once again. This eternal battle is depicted in rituals seen in Bali, and in recent times have become an attraction for tourists.\n"
+      "background": "Barong is the protector of mankind that represents the forces of good in Indonesian lore. It uses its charms and magic to defend villagers against the deathly black magic of the witch Rangda. He is a guardian spirit that is most commonly seen in the form of a lion, although each region within Bali has its own version of Barong, the others being a dragon, boar or a tiger. Barong is animated by the brother spirit Banas Pati Rajah to do battle with Rangda in order to restore the balance between good and evil. However, after Rangda is killed, she is eventually resurrected, and Barong must do battle once again. This eternal battle is depicted in rituals seen in Bali, and in recent times have become an attraction for tourists."
     },
     {
-      "name": "Garuda",
+      "name": "garuda",
+      "displayName": "Garuda",
       "evolvesTo": null,
       "primaryElement": "Wind",
       "level": "17",
@@ -7305,11 +7425,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +7 to hit, range 5 ft., one target. \u000bHit: 2d4 + 3 physical damage."
+          "description": "Melee attack: +7 to hit, range 5 ft., one target.\nHit: 2d4 + 3 physical damage."
         },
         {
           "name": "Garudyne (7 SP, 1 action)",
-          "description": "A maelstrom wraps around a target, buffeting them into oblivion. Make a ranged attack against a creature within range (+3 to hit, 90 feet). On a hit, they receive \u000b6d8 + 4 wind damage"
+          "description": "A maelstrom wraps around a target, buffeting them into oblivion. Make a ranged attack against a creature within range (+3 to hit, 90 feet). On a hit, they receive\n6d8 + 4 wind damage"
         },
         {
           "name": "Mind Slice (12 HP, 2 actions)",
@@ -7320,10 +7440,11 @@
           "description": "You accelerate each of your allies to rapid speeds. Choose up to six creatures within range (90 feet). Those creatures gain the effects of Sukukaja."
         }
       ],
-      "background": "In Hindu mythology, Garuda is a lesser Hindu divinity, usually the mount of Vishnu. Garuda is depicted as having a golden body, white face, red wings and an eagle's beak, but with a strong man's body. He wears a crown on his head. He is an ancient powerful creature in the epics, whose wing flapping can stop the spinning of heaven, earth and underworld, as well as large enough to block out the sun. The Satapatha Brahmana mentions Garuda as the personification of courage. In the Mahabharata, Garutman is stated to be the same as Garuda, then described as the one who is fast, who can shapeshift into any form and enter anywhere.\n"
+      "background": "In Hindu mythology, Garuda is a lesser Hindu divinity, usually the mount of Vishnu. Garuda is depicted as having a golden body, white face, red wings and an eagle's beak, but with a strong man's body. He wears a crown on his head. He is an ancient powerful creature in the epics, whose wing flapping can stop the spinning of heaven, earth and underworld, as well as large enough to block out the sun. The Satapatha Brahmana mentions Garuda as the personification of courage. In the Mahabharata, Garutman is stated to be the same as Garuda, then described as the one who is fast, who can shapeshift into any form and enter anywhere."
     },
     {
-      "name": "Jatayu",
+      "name": "jatayu",
+      "displayName": "Jatayu",
       "evolvesTo": null,
       "primaryElement": "Wind",
       "level": "17",
@@ -7362,7 +7483,7 @@
       "traits": [
         {
           "name": "Speed Master",
-          "description": "You have a unique sense for agile tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Sukukaja Skill at no cost or action "
+          "description": "You have a unique sense for agile tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Sukukaja Skill at no cost or action "
         },
         {
           "name": "Elemental Amp (Wind)",
@@ -7372,11 +7493,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 2d4 + 3 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 2d4 + 3 physical damage."
         },
         {
           "name": "Garudyne (14 SP, 1 action)",
-          "description": "A maelstrom wraps around a target, buffeting them into oblivion. Make a ranged attack against a creature within range (+3 to hit, 90 feet). On a hit, they receive \u000b6d8 + 4 wind damage"
+          "description": "A maelstrom wraps around a target, buffeting them into oblivion. Make a ranged attack against a creature within range (+3 to hit, 90 feet). On a hit, they receive\n6d8 + 4 wind damage"
         },
         {
           "name": "Nocturnal Flash (10 SP, 2 actions)",
@@ -7387,10 +7508,11 @@
           "description": "You accelerate each of your allies to rapid speeds. Choose up to six creatures within range (90 feet). Those creatures gain the effects of Sukukaja."
         }
       ],
-      "background": "Jatayu is a valiant bird in the legends that depicted it. In the Hindu epic Ramayana, Jatayu is an old friend of Rama. It attempted to rescue Rama's wife Sita after she was kidnapped by Ravana, the devil-king. A fierce battle ensued, but Ravana managed to defeat Jatayu by slashing its wings. In a Malay literature, Hikayat Merong Mahawangsa, Jatayu is the nephew of the giant bird Garuda. It was summoned by King Merong Mahawangsa, a friend of the prince of Rome, to rescue the prince's betrothed, a Chinese princess who was kidnapped by Garuda. Despite its determination, Garuda managed to overpower Jatayu.\n"
+      "background": "Jatayu is a valiant bird in the legends that depicted it. In the Hindu epic Ramayana, Jatayu is an old friend of Rama. It attempted to rescue Rama's wife Sita after she was kidnapped by Ravana, the devil-king. A fierce battle ensued, but Ravana managed to defeat Jatayu by slashing its wings. In a Malay literature, Hikayat Merong Mahawangsa, Jatayu is the nephew of the giant bird Garuda. It was summoned by King Merong Mahawangsa, a friend of the prince of Rome, to rescue the prince's betrothed, a Chinese princess who was kidnapped by Garuda. Despite its determination, Garuda managed to overpower Jatayu."
     },
     {
-      "name": "Mishaguji",
+      "name": "mishaguji",
+      "displayName": "Mishaguji",
       "evolvesTo": null,
       "primaryElement": "Ailment",
       "level": "17",
@@ -7434,17 +7556,17 @@
         },
         {
           "name": "Hollow Jester",
-          "description": "You seek out the weak-willed and the ailing pack. You gain the following benefits:\n \u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n \u2022 You may add half your character level (min 1) to the damage roll of any attack against a target afflicted with a Condition. You may add this bonus multiple times, once for each Condition the target is inflicted with. "
+          "description": "You seek out the weak-willed and the ailing pack. You gain the following benefits:\n\u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n\u2022 You may add half your character level (min 1) to the damage roll of any attack against a target afflicted with a Condition. You may add this bonus multiple times, once for each Condition the target is inflicted with. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 2d6 + 3 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 2d6 + 3 physical damage."
         },
         {
           "name": "Brain Jack (10 SP, 2 actions)",
-          "description": "You\u2019re not asking anymore. You use magic to directly weave into the hearts of foes, seizing control of the field. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range \u000b(+3 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Brainwash (see \u201cConditions\u201d)."
+          "description": "You\u2019re not asking anymore. You use magic to directly weave into the hearts of foes, seizing control of the field. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range\n(+3 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Brainwash (see \u201cConditions\u201d)."
         },
         {
           "name": "One-Shot Kill (9 HP, 1 action)",
@@ -7458,7 +7580,8 @@
       "background": "Mishaguji was a native god worshiped in the ancient Shinto region of Japan before the Yamato took control, at which point the worship of it became a taboo. Mishaguji was the god of sexual intercourse and if he was left an offering, then sex would become better. It is said that Mishaguji's incarnation on Earth had a very phallic shape, possibly similar to an earthworm, and he would take shelter under rocks or stones. Once Yamato took control, however, Mishaguji became seen as a god that only the undesirable and unfaithful would worship."
     },
     {
-      "name": "Norn",
+      "name": "norn",
+      "displayName": "Norn",
       "evolvesTo": null,
       "primaryElement": "Wind",
       "level": "17",
@@ -7496,7 +7619,7 @@
       "traits": [
         {
           "name": "Survival Trick",
-          "description": "With deceit and trickery, as well as resilience, you are able to avoid disaster. You gain the following benefits:\n \u2022 When you would be reduced to 0 hit points by a Hama or Mudo type Skill, or Door of Hades, you are reduced to 1 hit points instead.\n \u2022 When you would be reduced to 0 hit points by a hostile attack that is not a Hama or Mudo type Skill, or Door of Hades , you are reduced to 1 hit point instead. Once this ability is used, you cannot use it again until you fully recover in Reality."
+          "description": "With deceit and trickery, as well as resilience, you are able to avoid disaster. You gain the following benefits:\n\u2022 When you would be reduced to 0 hit points by a Hama or Mudo type Skill, or Door of Hades, you are reduced to 1 hit points instead.\n\u2022 When you would be reduced to 0 hit points by a hostile attack that is not a Hama or Mudo type Skill, or Door of Hades , you are reduced to 1 hit point instead. Once this ability is used, you cannot use it again until you fully recover in Reality."
         },
         {
           "name": "Fast Heal",
@@ -7506,26 +7629,27 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 2d8 + 3 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 2d8 + 3 physical damage."
         },
         {
           "name": "Garudyne (14 SP, 1 action)",
-          "description": "A maelstrom wraps around a target, buffeting them into oblivion. Make a ranged attack against a creature within range (+3 to hit, 90 feet). On a hit, they receive \u000b3d8 + 4 wind damage."
+          "description": "A maelstrom wraps around a target, buffeting them into oblivion. Make a ranged attack against a creature within range (+3 to hit, 90 feet). On a hit, they receive\n3d8 + 4 wind damage."
         },
         {
           "name": "Ziodyne (16 SP, 1 action)",
-          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+3 to hit, 30 feet). On a hit, they receive \u000b3d8 + 4 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
+          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+3 to hit, 30 feet). On a hit, they receive\n3d8 + 4 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
         },
         {
           "name": "Samarecarm (28 SP, 1 action)",
           "description": "A wellspring of youth and vigor comes forth, nurturing an ally with new health. Choose a creature that is knocked out within range (90 feet). That creature regains all of their missing hit points."
         }
       ],
-      "background": "Norn, also known as Nornir, are the numerous female goddesses who rule the fates of the various races that exist in Norse Mythology. The three most important of the Norns are Urd, Verdandi and Skuld. These three are said to live near a lake under the roots of Yggdrasil, the world tree.\n They come out from a hall standing at the Well of Ur\u00f0r (Fate). They draw water from the well and take sand that lies around it, which they pour over the Yggdrasil tree so that its branches will not rot. These three main Norns are described as powerful maiden giantesses (Jotuns) whose arrival from J\u00f6tunheimr ended the golden age of the gods.\n"
+      "background": "Norn, also known as Nornir, are the numerous female goddesses who rule the fates of the various races that exist in Norse Mythology. The three most important of the Norns are Urd, Verdandi and Skuld. These three are said to live near a lake under the roots of Yggdrasil, the world tree.\n\nThey come out from a hall standing at the Well of Ur\u00f0r (Fate). They draw water from the well and take sand that lies around it, which they pour over the Yggdrasil tree so that its branches will not rot. These three main Norns are described as powerful maiden giantesses (Jotuns) whose arrival from J\u00f6tunheimr ended the golden age of the gods."
     },
     {
-      "name": "Sarasvati",
-      "evolvesTo": "Parvati",
+      "name": "sarasvati",
+      "displayName": "Sarasvati",
+      "evolvesTo": "parvati",
       "primaryElement": "Healing",
       "level": "17",
       "arcana": "Priestess",
@@ -7566,13 +7690,13 @@
         },
         {
           "name": "Majestic Presence",
-          "description": "When you have the initiative, you can unleash a storm of gunfire on foes, in addition to your cheap shots. You gain the following benefits:\n \u2022 Whenever a creature would regain hit points from a Skill within 60 feet, you may add a 2d8 bonus to the amount regained. This bonus is increased by 2d8 at 15th level (4d8).\n \u2022 Whenever a creature within 60 feet of you uses a Healing Skill, you may roll 1d4. On a 4, the spell point cost of that Skill is halved for that use, to a minimum of 1. "
+          "description": "When you have the initiative, you can unleash a storm of gunfire on foes, in addition to your cheap shots. You gain the following benefits:\n\u2022 Whenever a creature would regain hit points from a Skill within 60 feet, you may add a 2d8 bonus to the amount regained. This bonus is increased by 2d8 at 15th level (4d8).\n\u2022 Whenever a creature within 60 feet of you uses a Healing Skill, you may roll 1d4. On a 4, the spell point cost of that Skill is halved for that use, to a minimum of 1. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +6 to hit, range 5 ft., one target. \u000bHit: 2d4 + 2 physical damage."
+          "description": "Melee attack: +6 to hit, range 5 ft., one target.\nHit: 2d4 + 2 physical damage."
         },
         {
           "name": "Element Wall (5 SP, 1 action)",
@@ -7587,10 +7711,11 @@
           "description": "Many tendrils swirl about, poised, then burrow into the minds of a battlefield to unsettle all. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range (+4 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Confuse (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Sarasvati, also known as Saraswati, is the goddess of knowledge, music and the arts in Hindu mythology. She has been identified with the Vedic Sarasvati River. She is considered as consort of Brahma, the Hindu god of creation. Thus, with the goddesses Lakshmi and Parvati, she forms the Tridevi, who are consorts of the male trinity, the Trimurti, consisting of Brahma, Vishnu and Shiva, respectively. Sarasvati's children are the Vedas, which are the oldest sacred texts of Hinduism.\n She is known in East Asia as Benzaiten or Biancaitian (\u5f01\u8ca1\u5929, Benzaiten)?, one of the Seven Lucky Gods in Japanese regional belief.\n"
+      "background": "Sarasvati, also known as Saraswati, is the goddess of knowledge, music and the arts in Hindu mythology. She has been identified with the Vedic Sarasvati River. She is considered as consort of Brahma, the Hindu god of creation. Thus, with the goddesses Lakshmi and Parvati, she forms the Tridevi, who are consorts of the male trinity, the Trimurti, consisting of Brahma, Vishnu and Shiva, respectively. Sarasvati's children are the Vedas, which are the oldest sacred texts of Hinduism.\n\nShe is known in East Asia as Benzaiten or Biancaitian (\u5f01\u8ca1\u5929, Benzaiten)?, one of the Seven Lucky Gods in Japanese regional belief."
     },
     {
-      "name": "Seth",
+      "name": "seth",
+      "displayName": "Seth",
       "evolvesTo": null,
       "primaryElement": "Gun",
       "level": "17",
@@ -7634,13 +7759,13 @@
         },
         {
           "name": "Down Shot",
-          "description": "A combination of skill and flamboyant carelessness lets you perform a special maneuver of covering fire. You gain the following benefits:\n \u2022 Whenever you roll 3d6 to make a Gun attack, if each d6 is the same result, the attack is a Critical hit.\n \u2022 As 1 action, you unleash a barrage of covering fire at a target within range of your firearm. This deals no damage, however the target is Downed. Once you use this ability, you cannot do so again until you fully recover in Reality. "
+          "description": "A combination of skill and flamboyant carelessness lets you perform a special maneuver of covering fire. You gain the following benefits:\n\u2022 Whenever you roll 3d6 to make a Gun attack, if each d6 is the same result, the attack is a Critical hit.\n\u2022 As 1 action, you unleash a barrage of covering fire at a target within range of your firearm. This deals no damage, however the target is Downed. Once you use this ability, you cannot do so again until you fully recover in Reality. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +2 to hit, range 5 ft., one target. \u000bHit: 2d8 + 3 physical damage."
+          "description": "Melee attack: +2 to hit, range 5 ft., one target.\nHit: 2d8 + 3 physical damage."
         },
         {
           "name": "One-Shot Kill (9 HP, 1 action)",
@@ -7655,10 +7780,11 @@
           "description": "You accelerate each of your allies to rapid speeds. Choose up to six creatures within range (90 feet). Those creatures gain the effects of Sukukaja."
         }
       ],
-      "background": "Set, also spelled Seth, Sutekh or S\u016bta\u1e2b, is a deity from Egyptian mythology. Set is the deity of deserts, storms and chaos and served as one of the greatest deities in Egyptian myth. Set was married to the goddess Nephthys, who was also his sister. He killed and dismembered his brother Osiris out of jealousy. Isis, Osiris' wife and sister, reassembled him and Osiris became the ruler of the dead. Isis gave birth to Osiris's child, Horus, who became an enemy of Set. In earlier myths, Set fought Apep each night as Ra journeyed through the underworld.\n"
+      "background": "Set, also spelled Seth, Sutekh or S\u016bta\u1e2b, is a deity from Egyptian mythology. Set is the deity of deserts, storms and chaos and served as one of the greatest deities in Egyptian myth. Set was married to the goddess Nephthys, who was also his sister. He killed and dismembered his brother Osiris out of jealousy. Isis, Osiris' wife and sister, reassembled him and Osiris became the ruler of the dead. Isis gave birth to Osiris's child, Horus, who became an enemy of Set. In earlier myths, Set fought Apep each night as Ra journeyed through the underworld."
     },
     {
-      "name": "Tsukiyomi",
+      "name": "tsukiyomi",
+      "displayName": "Tsukiyomi",
       "evolvesTo": null,
       "primaryElement": "Curse",
       "level": "17",
@@ -7697,7 +7823,7 @@
       "traits": [
         {
           "name": "Bolstering Force",
-          "description": "The first was terror. Your second strike is a nightmare. You gain the following benefits:\n \u2022 You may add half your character level (min 1) to the damage roll of any attack made using an action granted by a One More!\n \u2022 You may add half your character level (min 1) to the damage roll of any attack against a target afflicted with a Condition."
+          "description": "The first was terror. Your second strike is a nightmare. You gain the following benefits:\n\u2022 You may add half your character level (min 1) to the damage roll of any attack made using an action granted by a One More!\n\u2022 You may add half your character level (min 1) to the damage roll of any attack against a target afflicted with a Condition."
         },
         {
           "name": "Elemental Amp (Curse)",
@@ -7707,7 +7833,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 2d6 + 4 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 2d6 + 4 physical damage."
         },
         {
           "name": "Abyssal Wings (24 SP, 2 actions)",
@@ -7715,18 +7841,19 @@
         },
         {
           "name": "Spirit Drain (5 SP, 1 action)",
-          "description": "You sate your aural thirst with the magical powers and thoughts of your foe, absorbing their essence. Make a ranged attack against a creature within range \u000b(+4 to hit, 30 feet). On a hit, the creature loses and you regain Spell Points equal to 8. This counts as damage for triggering Draining Mouth type Traits."
+          "description": "You sate your aural thirst with the magical powers and thoughts of your foe, absorbing their essence. Make a ranged attack against a creature within range\n(+4 to hit, 30 feet). On a hit, the creature loses and you regain Spell Points equal to 8. This counts as damage for triggering Draining Mouth type Traits."
         },
         {
           "name": "Vorpal Blade (7 HP, 2 actions)",
           "description": "Blinding speed and surgical precision envelop an area with slashes. Make a melee attack against a creature within a 10-foot sphere, centered at a point within range (+4 to hit, 10 feet). On a hit, a creature receives 4d10 + 4 physical damage."
         }
       ],
-      "background": "Tsukuyomi is the lunar god in Shintoism. He was born of Izanagi's right eye as he bathed after his descent to the underworld, thus making him the brother of Amaterasu and Susano-o.\n"
+      "background": "Tsukuyomi is the lunar god in Shintoism. He was born of Izanagi's right eye as he bathed after his descent to the underworld, thus making him the brother of Amaterasu and Susano-o."
     },
     {
-      "name": "Cerberus",
-      "evolvesTo": "Chimera",
+      "name": "cerberus",
+      "displayName": "Cerberus",
+      "evolvesTo": "chimera",
       "primaryElement": "Fire",
       "level": "18",
       "arcana": "Chariot",
@@ -7773,7 +7900,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 2d8 + 5 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 2d8 + 5 physical damage."
         },
         {
           "name": "Agidyne (8 SP, 1 action)",
@@ -7788,11 +7915,12 @@
           "description": "Golden light of obstinance heightens an ally\u2019s ability to deliver punishment. Choose a creature within range (90 feet). For 1 minute, attacks the creature makes score a Critical hit if the result of each d6 is a 5 or higher."
         }
       ],
-      "background": "In Greek mythology, Cerberus, also known as Kerberos, is a monster and pet under Hades that guards the gates of the Greek underworld, the realm of Hades. It is generally depicted as a vicious, gargantuan dog with three heads, although accounts may vary. Cerberus is in fact the Latin transliteration of the Greek name Kerberos.\n Cerberus was one of the monsters born from the union of Echidna and Typhon, both as monstrous and hideous as their offspring. Echidna was half-woman, half-serpent, while Typhon was the most fierce of all creatures. Among his brothers, the most famous are the Lernaean Hydra, Chimera, and Orthrus.\n"
+      "background": "In Greek mythology, Cerberus, also known as Kerberos, is a monster and pet under Hades that guards the gates of the Greek underworld, the realm of Hades. It is generally depicted as a vicious, gargantuan dog with three heads, although accounts may vary. Cerberus is in fact the Latin transliteration of the Greek name Kerberos.\n\nCerberus was one of the monsters born from the union of Echidna and Typhon, both as monstrous and hideous as their offspring. Echidna was half-woman, half-serpent, while Typhon was the most fierce of all creatures. Among his brothers, the most famous are the Lernaean Hydra, Chimera, and Orthrus."
     },
     {
-      "name": "Ganesha",
-      "evolvesTo": "Vishnu",
+      "name": "ganesha",
+      "displayName": "Ganesha",
+      "evolvesTo": "vishnu",
       "primaryElement": "Support",
       "level": "18",
       "arcana": "Sun",
@@ -7834,13 +7962,13 @@
         },
         {
           "name": "Flow",
-          "description": "Momentum lifts you up and carries you forward. You gain the following benefits:\n \u2022 Whenever you roll Initiative, roll 1d4. On a 4, you gain the benefits of Power Charge and Concentrate at no cost."
+          "description": "Momentum lifts you up and carries you forward. You gain the following benefits:\n\u2022 Whenever you roll Initiative, roll 1d4. On a 4, you gain the benefits of Power Charge and Concentrate at no cost."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 2d4 + 5 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 2d4 + 5 physical damage."
         },
         {
           "name": "Tetraja (5 SP, 2 actions)",
@@ -7855,10 +7983,11 @@
           "description": "You seize the opportunity that fate has laid before you, making this strike count. Make a melee attack against a creature within range (+2 to hit, 10 feet). A creature hit by this attack receives 2d10 + 5 physical damage. This Skill scores a Critical hit if the result of each d6 in its attack roll is 5 or higher."
         }
       ],
-      "background": "Ganesha (also called Ganesh or Ganesa) is one of the most worshiped deities in the Hindu pantheon and is known as the Lord of Obstacles, Lord of Beginnings, god of wisdom and intelligence and patron of arts and science. He is the son of Shiva and Parvati and depicted as having the head of an elephant (often with one broken tusk), a pot-belly and anywhere from two to six arms.\n"
+      "background": "Ganesha (also called Ganesh or Ganesa) is one of the most worshiped deities in the Hindu pantheon and is known as the Lord of Obstacles, Lord of Beginnings, god of wisdom and intelligence and patron of arts and science. He is the son of Shiva and Parvati and depicted as having the head of an elephant (often with one broken tusk), a pot-belly and anywhere from two to six arms."
     },
     {
-      "name": "Okuninushi",
+      "name": "okuninushi",
+      "displayName": "Okuninushi",
       "evolvesTo": null,
       "primaryElement": "Psychic",
       "level": "18",
@@ -7907,17 +8036,18 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 2d8 + 5 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 2d8 + 5 physical damage."
         },
         {
           "name": "Psio (4 SP, 1 action)",
           "description": "Orbs appear from your fingertips, homing in on a foe and blasting them with concentrated dissonance. Make a ranged attack against a creature within range (+3 to hit, 90 feet). On a hit, they receive 5d8 + 4 psychic damage."
         }
       ],
-      "background": "Element Break (15 SP, 2 actions). You reach out your hand, and crush a foe\u2019s resilience to your attack. When you use this Skill, choose Fire, Ice, Electric, Wind, Psychic, or Nuke and up to six creatures within range (90 feet). For the next three rounds starting to count down at the end of this one, those creatures no longer Resist, Block, Drain, or Repel the chosen damage type. Additionally, this Skill removes all Tetrakarn and Makarakarn effects from affected creatures.\n"
+      "background": "Element Break (15 SP, 2 actions). You reach out your hand, and crush a foe\u2019s resilience to your attack. When you use this Skill, choose Fire, Ice, Electric, Wind, Psychic, or Nuke and up to six creatures within range (90 feet). For the next three rounds starting to count down at the end of this one, those creatures no longer Resist, Block, Drain, or Repel the chosen damage type. Additionally, this Skill removes all Tetrakarn and Makarakarn effects from affected creatures."
     },
     {
-      "name": "Pale Rider",
+      "name": "pale-rider",
+      "displayName": "Pale Rider",
       "evolvesTo": null,
       "primaryElement": "Ailment",
       "level": "18",
@@ -7955,7 +8085,7 @@
       "traits": [
         {
           "name": "Foul Stench",
-          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage "
+          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage "
         },
         {
           "name": "Elemental Amp (Curse)",
@@ -7965,7 +8095,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 2d6 + 3 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 2d6 + 3 physical damage."
         },
         {
           "name": "Abysmal Surge (10 SP, 2 actions)",
@@ -7980,11 +8110,12 @@
           "description": "Glowing, star-like spheres manifest above the field, then fire beams of destructive force by the dozens into foes. Make a ranged attack against up to six creatures within range (+3 to hit, 60 feet). On a hit, they receive 2d8 + 4 almighty damage."
         }
       ],
-      "background": "The Pale Rider, or Pale Horseman, is the fourth and final Horseman of the Apocalypse, according to Christian scripture. The rider traditionally represents death and bears a scythe of death. Despite typically being portrayed carrying a scythe as his weapon (much like the Grim Reaper), in the Book of Revelation, he is described as bringing Hades (Hell) wherever he rides as his symbol. His color being pale, as opposed to an actual color, could be reflecting the sickly appearance of a corpse (though old translations could be interpreted as the rider being pale green and yellowish green.)\n"
+      "background": "The Pale Rider, or Pale Horseman, is the fourth and final Horseman of the Apocalypse, according to Christian scripture. The rider traditionally represents death and bears a scythe of death. Despite typically being portrayed carrying a scythe as his weapon (much like the Grim Reaper), in the Book of Revelation, he is described as bringing Hades (Hell) wherever he rides as his symbol. His color being pale, as opposed to an actual color, could be reflecting the sickly appearance of a corpse (though old translations could be interpreted as the rider being pale green and yellowish green.)"
     },
     {
-      "name": "Raja Naga",
-      "evolvesTo": "Vasuki",
+      "name": "raja-naga",
+      "displayName": "Raja Naga",
+      "evolvesTo": "vasuki",
       "primaryElement": "Electric",
       "level": "18",
       "arcana": "Temperance",
@@ -8021,17 +8152,17 @@
         },
         {
           "name": "Static Electricity",
-          "description": "An overabundance of electrical power primes a foe for paralysis. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with Shock (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "An overabundance of electrical power primes a foe for paralysis. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with Shock (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 2d6 + 3 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 2d6 + 3 physical damage."
         },
         {
           "name": "Ziodyne (8 SP, 1 action)",
-          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+3 to hit, 30 feet). On a hit, they receive \u000b3d8 + 4 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
+          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+3 to hit, 30 feet). On a hit, they receive\n3d8 + 4 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
         },
         {
           "name": "Element Break (15 SP, 2 actions)",
@@ -8042,11 +8173,12 @@
           "description": "You form a shimmering barrier that mirrors arcane assaults. Choose a creature within range (90 feet). That creature Repels the next attack they receive within the next 10 minutes that deals Fire, Ice, Electric, Wind, Psychic, Nuke, Bless, or Curse damage (see \u201cDamage\u201d)."
         }
       ],
-      "background": "Naga Raja are the many kings of nagas with many stories involving them in Hindu mythology. Raja Naga also appear in Buddhist mythology, and their duties consist of leading the nagas and protecting and worshipping the Buddha, along with protecting other enlightened beings.\n"
+      "background": "Naga Raja are the many kings of nagas with many stories involving them in Hindu mythology. Raja Naga also appear in Buddhist mythology, and their duties consist of leading the nagas and protecting and worshipping the Buddha, along with protecting other enlightened beings."
     },
     {
-      "name": "Skadi",
-      "evolvesTo": "Scathach",
+      "name": "skadi",
+      "displayName": "Skadi",
+      "evolvesTo": "scathach",
       "primaryElement": "Physical",
       "level": "18",
       "arcana": "Priestess",
@@ -8091,7 +8223,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 2d4 + 3 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 2d4 + 3 physical damage."
         },
         {
           "name": "Deadly Fury (13 HP, 1 action)",
@@ -8106,10 +8238,11 @@
           "description": "Dark energy pours from your mouth, manifesting in a banshee\u2019s cry that severs the souls of the weak-willed. This Skill affects all creatures within range, including yourself and allies (30 feet). Each creature afflicted by the Fear condition (see \u201cConditions\u201d) within range is reduced to 0 hit points immediately."
         }
       ],
-      "background": "Skadi (Norse: Ska\u00f0i), alternatively referred to as \u00d6ndurgu\u00f0 or \u00d6ndurd\u00eds (lit: Snowshoe goddess), is a j\u00f6tunn, a giantess in Norse mythology. Associated with skiing, hunting and winter, she is the daughter of Thjazi, one-time wife of the god Nj\u00f6r\u00f0ur, and stepmother of Freyr and Freya.\n In The Woman's Encyclopedia of Myths and Secrets authored by Barbara G. Walker in 1983, Skadi was said to be a Celtic goddess who carries the meaning of darkness and shadow, and thus an equivalent to the Irish Scathach. Today, many unique interpretations of mythological figures including Skadi and Mem Aleph by Walker are largely dismissed as unreliable, but her influence has already been spread to modern popular culture including the Megami Tensei series. Not only Skadi's design by Kazuma Kaneko which is completely black from head to toe, in the Japanese version of all games of the series, Skadi's background commentary recycles the same prose which cites Walker's theory without mentioning Skadi's origin as a Norse snowshoe goddess.\n"
+      "background": "Skadi (Norse: Ska\u00f0i), alternatively referred to as \u00d6ndurgu\u00f0 or \u00d6ndurd\u00eds (lit: Snowshoe goddess), is a j\u00f6tunn, a giantess in Norse mythology. Associated with skiing, hunting and winter, she is the daughter of Thjazi, one-time wife of the god Nj\u00f6r\u00f0ur, and stepmother of Freyr and Freya.\n\nIn The Woman's Encyclopedia of Myths and Secrets authored by Barbara G. Walker in 1983, Skadi was said to be a Celtic goddess who carries the meaning of darkness and shadow, and thus an equivalent to the Irish Scathach. Today, many unique interpretations of mythological figures including Skadi and Mem Aleph by Walker are largely dismissed as unreliable, but her influence has already been spread to modern popular culture including the Megami Tensei series. Not only Skadi's design by Kazuma Kaneko which is completely black from head to toe, in the Japanese version of all games of the series, Skadi's background commentary recycles the same prose which cites Walker's theory without mentioning Skadi's origin as a Norse snowshoe goddess."
     },
     {
-      "name": "Asterius",
+      "name": "asterius",
+      "displayName": "Asterius",
       "evolvesTo": null,
       "primaryElement": "Fire",
       "level": "19",
@@ -8152,13 +8285,13 @@
         },
         {
           "name": "Boosted Rage",
-          "description": "Your berserk fury knows little to no bounds. You gain the following benefits:\n \u2022 While inflicted with Rage (see \u201cConditions\u201d), damage dealt by basic melee weapon attacks by you is doubled.\n \u2022 As 1 action, you enter a frenzied state. This grants you the effects of the Tarukaja Skill at no cost. Then, make a melee attack against yourself. If the result of all d6s in this attack are a 3 or higher, you are inflicted with Rage\n (see \u201cConditions\u201d). You may willingly be inflicted with Rage this way. "
+          "description": "Your berserk fury knows little to no bounds. You gain the following benefits:\n\u2022 While inflicted with Rage (see \u201cConditions\u201d), damage dealt by basic melee weapon attacks by you is doubled.\n\u2022 As 1 action, you enter a frenzied state. This grants you the effects of the Tarukaja Skill at no cost. Then, make a melee attack against yourself. If the result of all d6s in this attack are a 3 or higher, you are inflicted with Rage\n(see \u201cConditions\u201d). You may willingly be inflicted with Rage this way. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 2d8 + 5 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 2d8 + 5 physical damage."
         },
         {
           "name": "Titanomachia (32 SP, 2 actions)",
@@ -8173,11 +8306,12 @@
           "description": "A tectonic force crumbles and fissures the earth, unleashing pure destruction on your foes. Make a melee attack against each creature within a 20-foot sphere centered at a point within range (+3 to hit, 20 feet). A creature hit by this attack receives 6d8 + 5 physical damage."
         }
       ],
-      "background": "The first Asterion was a sacred king of Crete whose wife Europa was seduced by Zeus when he assumed the form of the Cretan bull, producing Minos. He is the son of Tectamus and an unnamed daughter of Cretheus. His father sailed to Crete and became the ruler of the island. Asterion inherited the throne from his father and he was the king of Crete at the time and married Europa, who was abducted by Zeus, becoming the stepfather of her sons by Zeus. Asterion brought up his stepsons, one of them being Minos and when he died childless, Minos took the throne and \"banished\" his brothers.\n The second Asterion was in fact the Minotaur, star at the center of the labyrinth on Cretan coins, the son of Minos's wife fathered by the Cretan Bull as punishment for Minos not sacrificing it in Poseidon's honor. \"Minotaur\" is simply a name of Hellenic coining to describe his Cretan symbolism, since \"Minotaur\" is a portmanteau of Minos and ta\u00fbros, the Greek word for bull."
+      "background": "The first Asterion was a sacred king of Crete whose wife Europa was seduced by Zeus when he assumed the form of the Cretan bull, producing Minos. He is the son of Tectamus and an unnamed daughter of Cretheus. His father sailed to Crete and became the ruler of the island. Asterion inherited the throne from his father and he was the king of Crete at the time and married Europa, who was abducted by Zeus, becoming the stepfather of her sons by Zeus. Asterion brought up his stepsons, one of them being Minos and when he died childless, Minos took the throne and \"banished\" his brothers.\n\nThe second Asterion was in fact the Minotaur, star at the center of the labyrinth on Cretan coins, the son of Minos's wife fathered by the Cretan Bull as punishment for Minos not sacrificing it in Poseidon's honor. \"Minotaur\" is simply a name of Hellenic coining to describe his Cretan symbolism, since \"Minotaur\" is a portmanteau of Minos and ta\u00fbros, the Greek word for bull."
     },
     {
-      "name": "Baphomet",
-      "evolvesTo": "Nebiros",
+      "name": "baphomet",
+      "displayName": "Baphomet",
+      "evolvesTo": "nebiros",
       "primaryElement": "Fire",
       "level": "19",
       "arcana": "Devil",
@@ -8215,17 +8349,17 @@
       "traits": [
         {
           "name": "Ghost Nest",
-          "description": "Ethereal claws of your will aid in penetrating the defenses of others. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with a Condition, roll 1d4. On a 4, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "Ethereal claws of your will aid in penetrating the defenses of others. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with a Condition, roll 1d4. On a 4, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         },
         {
           "name": "Gaia Blessing",
-          "description": "With your blessing, you ride into battle and crush enemies underneath, heightening the elemental powers around you. Additionally, your Persona/Demonic abilities manifest in a vehicular way:\n \u2022 Whenever you or a creature within 30 feet of you attempts to inflict a target with Burn, Shock, or Freeze, you may roll 1d4. On a 4, the Condition is successfully inflicted. "
+          "description": "With your blessing, you ride into battle and crush enemies underneath, heightening the elemental powers around you. Additionally, your Persona/Demonic abilities manifest in a vehicular way:\n\u2022 Whenever you or a creature within 30 feet of you attempts to inflict a target with Burn, Shock, or Freeze, you may roll 1d4. On a 4, the Condition is successfully inflicted. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 2d4 + 3 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 2d4 + 3 physical damage."
         },
         {
           "name": "Agidyne (16 SP, 1 action)",
@@ -8237,13 +8371,14 @@
         },
         {
           "name": "Ziodyne (16 SP, 1 action)",
-          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+3 to hit, 30 feet). On a hit, they receive \u000b3d8 + 5 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
+          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+3 to hit, 30 feet). On a hit, they receive\n3d8 + 5 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Baphomet is a king of demons, known as the \"Sabbatic Goat.\" He is identified with Satanachia, a senior demon general described in the Grand Grimoire. His name is believed to be a corruption of Muhammad, the founder of Islam. He is usually depicted with the head of a goat, with a pentagram carved between his horns, and the body of a human woman or hermaphrodite. He has the power to control all human women, and is said to give witches their power, thus, famously known as a demon worshipped by witches.\n The Knights Templar, heroes of the Crusades, were accused of worshipping Baphomet by a church inquisition and branded as heretics. To keep them silent, the head of the Templars and another senior leader were sentenced to be burned alive. However, it was later revealed that this was orchestrated by King Philip IV of France, who coveted the Templars' wealth.\n"
+      "background": "Baphomet is a king of demons, known as the \"Sabbatic Goat.\" He is identified with Satanachia, a senior demon general described in the Grand Grimoire. His name is believed to be a corruption of Muhammad, the founder of Islam. He is usually depicted with the head of a goat, with a pentagram carved between his horns, and the body of a human woman or hermaphrodite. He has the power to control all human women, and is said to give witches their power, thus, famously known as a demon worshipped by witches.\n\nThe Knights Templar, heroes of the Crusades, were accused of worshipping Baphomet by a church inquisition and branded as heretics. To keep them silent, the head of the Templars and another senior leader were sentenced to be burned alive. However, it was later revealed that this was orchestrated by King Philip IV of France, who coveted the Templars' wealth."
     },
     {
-      "name": "Chernobog",
+      "name": "chernobog",
+      "displayName": "Chernobog",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "19",
@@ -8285,7 +8420,7 @@
       "traits": [
         {
           "name": "Crisis Control",
-          "description": "You not only exploit weakness effectively, but know how to guard your own. You gain the following benefits:\n \u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n \u2022 You receive half as much damage from attacks against which you are Weak."
+          "description": "You not only exploit weakness effectively, but know how to guard your own. You gain the following benefits:\n\u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n\u2022 You receive half as much damage from attacks against which you are Weak."
         },
         {
           "name": "Striking Weight",
@@ -8295,7 +8430,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 2d6 + 4 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 2d6 + 4 physical damage."
         },
         {
           "name": "Bloodbath (16 HP, 2 actions)",
@@ -8310,11 +8445,12 @@
           "description": "Darkness and malevolent spirits crush the victim\u2019s will. Choose a creature within range and make a ranged attack against them (+3 to hit, 90 feet). On a hit, if the result of each d6 is 3 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Curse. This Skill provokes a One More if the target is weak to Curse."
         }
       ],
-      "background": "Chernobog, whose name means Black God, is an alleged Slavic deity of darkness and bad faith. Chernobog is not often mentioned in Slavic pagan sources, but is mentioned by the Western Slavs. He is associated with destruction, darkness and the winter. Due to this, he wasn't worshiped but instead avoided, just like Baba Yaga. This conflicts with the Slavic pagan customs of pleasing gods/goddesses and spirits in order to gain their blessing and protection. He is also synonymous with evil and later became synonymous with the devil.\n"
+      "background": "Chernobog, whose name means Black God, is an alleged Slavic deity of darkness and bad faith. Chernobog is not often mentioned in Slavic pagan sources, but is mentioned by the Western Slavs. He is associated with destruction, darkness and the winter. Due to this, he wasn't worshiped but instead avoided, just like Baba Yaga. This conflicts with the Slavic pagan customs of pleasing gods/goddesses and spirits in order to gain their blessing and protection. He is also synonymous with evil and later became synonymous with the devil."
     },
     {
-      "name": "Melchizedek",
-      "evolvesTo": "Sandalphon",
+      "name": "melchizedek",
+      "displayName": "Melchizedek",
+      "evolvesTo": "sandalphon",
       "primaryElement": "Bless",
       "level": "19",
       "arcana": "Justice",
@@ -8363,7 +8499,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 2d8 + 5 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 2d8 + 5 physical damage."
         },
         {
           "name": "Hamaon (12 SP, 1 action)",
@@ -8378,11 +8514,12 @@
           "description": "You unleash a large, concentrated wave of raw power and force. It shoots forward from your own, crushing those underneath it with obliterating impact. Make a melee attack against a creature within range (+3 to hit, 20 feet). On a hit, the creature receives 7d8 + 3 physical damage. You may move to an unoccupied space within 5 feet of the target after attacking. This attack may not connect if movement to this space is prevented."
         }
       ],
-      "background": "Melchizedek, also known as Melchisedech, Melkisetek or Malki Tzedek, is a biblical figure known for his wisdom. He was the king of Salem and priest of El Elyon mentioned in the 14th chapter of the Book of Genesis. He brings out bread and wine and then blesses Abram and El Elyon, in the time of Abraham.\n"
+      "background": "Melchizedek, also known as Melchisedech, Melkisetek or Malki Tzedek, is a biblical figure known for his wisdom. He was the king of Salem and priest of El Elyon mentioned in the 14th chapter of the Book of Genesis. He brings out bread and wine and then blesses Abram and El Elyon, in the time of Abraham."
     },
     {
-      "name": "Parvati",
-      "evolvesTo": "Ardha",
+      "name": "parvati",
+      "displayName": "Parvati",
+      "evolvesTo": "ardha",
       "primaryElement": "Healing",
       "level": "19",
       "arcana": "Lovers",
@@ -8424,13 +8561,13 @@
         },
         {
           "name": "Majestic Presence",
-          "description": "When you have the initiative, you can unleash a storm of gunfire on foes, in addition to your cheap shots. You gain the following benefits:\n \u2022 Whenever a creature would regain hit points from a Skill within 60 feet, you may add a 2d8 bonus to the amount regained. This bonus is increased by 2d8 at 15th level (4d8).\n \u2022 Whenever a creature within 60 feet of you uses a Healing Skill, you may roll 1d4. On a 4, the spell point cost of that Skill is halved for that use, to a minimum of 1. "
+          "description": "When you have the initiative, you can unleash a storm of gunfire on foes, in addition to your cheap shots. You gain the following benefits:\n\u2022 Whenever a creature would regain hit points from a Skill within 60 feet, you may add a 2d8 bonus to the amount regained. This bonus is increased by 2d8 at 15th level (4d8).\n\u2022 Whenever a creature within 60 feet of you uses a Healing Skill, you may roll 1d4. On a 4, the spell point cost of that Skill is halved for that use, to a minimum of 1. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 2d8 + 5 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 2d8 + 5 physical damage."
         },
         {
           "name": "Diarahan (18 SP, 1 action)",
@@ -8445,11 +8582,12 @@
           "description": "Magical medicine rains, honing the mind against uncontrolled emotions. Choose up to six creatures within range (60 feet). Each of those creatures recover from Confuse, Fear, Despair, Rage, and Brainwash (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Parvati is the Hindu goddess of fertility, love, beauty, harmony, marriage, children and devotion; as well as of divine strength and power. This beautiful goddess is also the second consort of Shiva in the Hindu mythology. A mountain princess, she is the reincarnation of the goddess Sati (Shiva's first consort), and won Shiva's love in her previous life despite his asceticism, but immolated herself after her father's disapproval. Reborn as Parvati, daughter of the snow mountain god Himalayas, she sought Shiva out. Because the gods required Shiva's offspring to defeat their fierce adversaries, they sacrificed Kama in order to stoke Shiva's suppressed desire for a female partner. The two reunited eventually and together gave birth to Kartikeya and later on, Ganesha. They have the ability to merge into the half-male, half-female Ardha.\ufeff\n"
+      "background": "Parvati is the Hindu goddess of fertility, love, beauty, harmony, marriage, children and devotion; as well as of divine strength and power. This beautiful goddess is also the second consort of Shiva in the Hindu mythology. A mountain princess, she is the reincarnation of the goddess Sati (Shiva's first consort), and won Shiva's love in her previous life despite his asceticism, but immolated herself after her father's disapproval. Reborn as Parvati, daughter of the snow mountain god Himalayas, she sought Shiva out. Because the gods required Shiva's offspring to defeat their fierce adversaries, they sacrificed Kama in order to stoke Shiva's suppressed desire for a female partner. The two reunited eventually and together gave birth to Kartikeya and later on, Ganesha. They have the ability to merge into the half-male, half-female Ardha.\ufeff"
     },
     {
-      "name": "Titiana",
-      "evolvesTo": "Cybele",
+      "name": "titiana",
+      "displayName": "Titiana",
+      "evolvesTo": "cybele",
       "primaryElement": "Nuke",
       "level": "19",
       "arcana": "Empress",
@@ -8490,13 +8628,13 @@
         },
         {
           "name": "Gaia Blessing",
-          "description": "With your blessing, you ride into battle and crush enemies underneath, heightening the elemental powers around you. Additionally, your Persona/Demonic abilities manifest in a vehicular way:\n \u2022 Whenever you or a creature within 30 feet of you attempts to inflict a target with Burn, Shock, or Freeze, you may roll 1d4. On a 4, the Condition is successfully inflicted."
+          "description": "With your blessing, you ride into battle and crush enemies underneath, heightening the elemental powers around you. Additionally, your Persona/Demonic abilities manifest in a vehicular way:\n\u2022 Whenever you or a creature within 30 feet of you attempts to inflict a target with Burn, Shock, or Freeze, you may roll 1d4. On a 4, the Condition is successfully inflicted."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 2d6 + 3 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 2d6 + 3 physical damage."
         },
         {
           "name": "Freidyne (16 SP, 1 action)",
@@ -8504,17 +8642,18 @@
         },
         {
           "name": "Ziodyne (16 SP, 1 action)",
-          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+3 to hit, 30 feet). On a hit, they receive \u000b3d8 + 5 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
+          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (+3 to hit, 30 feet). On a hit, they receive\n3d8 + 5 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
         },
         {
           "name": "Mediarahan (36 SP, 2 actions)",
           "description": "A cascade of verdant light basks many allies in a healing glow, healing their most grievous injury. Choose up to six creatures within range (90 feet). Those creatures regain 6d8 + 10 hit points."
         }
       ],
-      "background": "Titania is the high queen of the fae and the wife of the high fae king Oberon. With her faithful flower pixies by her side, she gathers magic from moonlight. Titania resides in the Kingdom of Fairyland, where she rules over the moonlit Fairy Forest. While considered stunningly beautiful and delicate, she is also portrayed as a very proud fairy, with powers that easily match those of her husband.\n"
+      "background": "Titania is the high queen of the fae and the wife of the high fae king Oberon. With her faithful flower pixies by her side, she gathers magic from moonlight. Titania resides in the Kingdom of Fairyland, where she rules over the moonlit Fairy Forest. While considered stunningly beautiful and delicate, she is also portrayed as a very proud fairy, with powers that easily match those of her husband."
     },
     {
-      "name": "Yatagarasu",
+      "name": "yatagarasu",
+      "displayName": "Yatagarasu",
       "evolvesTo": null,
       "primaryElement": "Support",
       "level": "19",
@@ -8562,7 +8701,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +7 to hit, range 5 ft., one target. \u000bHit: 2d4 + 3 physical damage."
+          "description": "Melee attack: +7 to hit, range 5 ft., one target.\nHit: 2d4 + 3 physical damage."
         },
         {
           "name": "Dekunda (12 SP, 2 actions)",
@@ -8577,11 +8716,12 @@
           "description": "A cascade of verdant light basks many allies in a healing glow, healing their most grievous injury. Choose up to six creatures within range (90 feet). Those creatures regain 6d8 + 10 hit points."
         }
       ],
-      "background": "Yatagarasu is a great divine bird that represents the will of heaven or divine intervention in human affairs in Japanese mythology. Although Yatagarasu is mentioned in a number of places in the Shinto canon, there is very little explanation, and much of the material is contradictory\n This great crow was sent from heaven as a guide for Emperor Jimmu on his initial journey from the region which would become Kumano to what would become Yamato. It is generally accepted that Yatagarasu is an incarnation of Taketsunimi, but none of the early surviving documentary records are quite so specific.\n None of the sources mention it having three legs either, and it may have been influenced by the Chinese sun bird Huoniao.\n"
+      "background": "Yatagarasu is a great divine bird that represents the will of heaven or divine intervention in human affairs in Japanese mythology. Although Yatagarasu is mentioned in a number of places in the Shinto canon, there is very little explanation, and much of the material is contradictory\n\nThis great crow was sent from heaven as a guide for Emperor Jimmu on his initial journey from the region which would become Kumano to what would become Yamato. It is generally accepted that Yatagarasu is an incarnation of Taketsunimi, but none of the early surviving documentary records are quite so specific.\n\nNone of the sources mention it having three legs either, and it may have been influenced by the Chinese sun bird Huoniao."
     },
     {
-      "name": "Black Rider",
-      "evolvesTo": "Loa",
+      "name": "black-rider",
+      "displayName": "Black Rider",
+      "evolvesTo": "loa",
       "primaryElement": "Almighty",
       "level": "20",
       "arcana": "Tower",
@@ -8619,7 +8759,7 @@
       "traits": [
         {
           "name": "Omen",
-          "description": "You are a living embodiment of purgation. You gain the following benefits:\n \u2022 You have advantage on attacks made for Hama, Hamaon, Samsara, Mudo, Mudoon,  Die for Me!, and Door of Hades.\n \u2022 Whenever you make an attack roll for Hama, Hamaon, Samsara, Mudo, Mudoon,  Die for Me!, or Door of Hades, you may reroll any of the dice once. You must use the new result."
+          "description": "You are a living embodiment of purgation. You gain the following benefits:\n\u2022 You have advantage on attacks made for Hama, Hamaon, Samsara, Mudo, Mudoon,  Die for Me!, and Door of Hades.\n\u2022 Whenever you make an attack roll for Hama, Hamaon, Samsara, Mudo, Mudoon,  Die for Me!, or Door of Hades, you may reroll any of the dice once. You must use the new result."
         },
         {
           "name": "Draining Mouth",
@@ -8629,7 +8769,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 2d8 + 3 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 2d8 + 3 physical damage."
         },
         {
           "name": "Megidola (24 SP, 2 actions)",
@@ -8644,10 +8784,11 @@
           "description": "A shocking blast of explosive force blinds foes. Make a melee attack against each creature within a 20-foot sphere centered at a point within range (+5 to hit, 20 feet). A creature hit by this attack receives 2d8 + 5 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Dizzy (see \u201cConditions\u201d)."
         }
       ],
-      "background": "The Black Rider, or Black Horsemen, is the third of the Four Horsemen of the Apocalypse, riding a black horse, popularly called Famine. The black color of the third horse symbolized death and famine, bearing a scale of famine. The rider rides onward, denying the world life-sustaining food and bringing starvation, but being ordered by divine law to not harm oil or wine. The rider is shown holding a scale, which represents scarcity of food, higher prices and famine, likely as a result of the wars caused by the red horseman. Food will be scarce, but luxuries such as wine and oil will still be readily available.\n"
+      "background": "The Black Rider, or Black Horsemen, is the third of the Four Horsemen of the Apocalypse, riding a black horse, popularly called Famine. The black color of the third horse symbolized death and famine, bearing a scale of famine. The rider rides onward, denying the world life-sustaining food and bringing starvation, but being ordered by divine law to not harm oil or wine. The rider is shown holding a scale, which represents scarcity of food, higher prices and famine, likely as a result of the wars caused by the red horseman. Food will be scarce, but luxuries such as wine and oil will still be readily available."
     },
     {
-      "name": "King Frost",
+      "name": "king-frost",
+      "displayName": "King Frost",
       "evolvesTo": null,
       "primaryElement": "Ice",
       "level": "20",
@@ -8693,7 +8834,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Bufudyne (8 SP, 1 action)",
@@ -8708,11 +8849,12 @@
           "description": "You gather and focus your mind's eye, delivering an absolute force of will. The next damage roll you make for an attack that deals Fire, Ice, Electric, Wind, Psychic, Nuke, Bless, Curse, or Almighty damage within the next 10 minutes is doubled."
         }
       ],
-      "background": "King Frost likely comes from \"The Frost Fairies,\" a short story written by Margaret T. Canby about King (Jack) Frost, a kind fairy king from the cold North.\n It is also just as likely that it's a pun about the fact that Jack and King are both playing card ranks.\n"
+      "background": "King Frost likely comes from \"The Frost Fairies,\" a short story written by Margaret T. Canby about King (Jack) Frost, a kind fairy king from the cold North.\n\nIt is also just as likely that it's a pun about the fact that Jack and King are both playing card ranks."
     },
     {
-      "name": "Lilith",
-      "evolvesTo": "Ishtar",
+      "name": "lilith",
+      "displayName": "Lilith",
+      "evolvesTo": "ishtar",
       "primaryElement": "Nuke",
       "level": "20",
       "arcana": "Moon",
@@ -8760,7 +8902,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +5 to hit, range 5 ft., one target. \u000bHit: 2d6 + 2 physical damage."
+          "description": "Melee attack: +5 to hit, range 5 ft., one target.\nHit: 2d6 + 2 physical damage."
         },
         {
           "name": "Freidyne (16 SP, 1 action)",
@@ -8772,13 +8914,14 @@
         },
         {
           "name": "Spirit Drain (5 SP, 1 action)",
-          "description": "You sate your aural thirst with the magical powers and thoughts of your foe, absorbing their essence. Make a ranged attack against a creature within range \u000b(+5 to hit, 30 feet). On a hit, the creature loses and you regain Spell Points equal to 10. This counts as damage that is not Physical or Gun for triggering Draining Mouth type Traits."
+          "description": "You sate your aural thirst with the magical powers and thoughts of your foe, absorbing their essence. Make a ranged attack against a creature within range\n(+5 to hit, 30 feet). On a hit, the creature loses and you regain Spell Points equal to 10. This counts as damage that is not Physical or Gun for triggering Draining Mouth type Traits."
         }
       ],
-      "background": "Lilith was originally a storm demon known as \"Lilitu\" in ancient Mesopotamian myth around 3000 BC and she was thought to have been the cause of disease, illness, and death. She later appears as a nocturnal demon in Jewish lore.\n In Judaism, Lilith was the first wife of Adam, however she was cast out of the garden of Eden for her sinful ways or because she desired to be his equal and refused to obey him. In one tale, she was the first to eat the fruit of knowledge and wanted to be either equal to or greater than Adam. After she left the garden of Eden, she attempted to create her own garden and became the consort of many different demons, including the fallen angel Samael, and bore many demons including the succubi known as the Lilim.\n"
+      "background": "Lilith was originally a storm demon known as \"Lilitu\" in ancient Mesopotamian myth around 3000 BC and she was thought to have been the cause of disease, illness, and death. She later appears as a nocturnal demon in Jewish lore.\n\nIn Judaism, Lilith was the first wife of Adam, however she was cast out of the garden of Eden for her sinful ways or because she desired to be his equal and refused to obey him. In one tale, she was the first to eat the fruit of knowledge and wanted to be either equal to or greater than Adam. After she left the garden of Eden, she attempted to create her own garden and became the consort of many different demons, including the fallen angel Samael, and bore many demons including the succubi known as the Lilim."
     },
     {
-      "name": "Moloch",
+      "name": "moloch",
+      "displayName": "Moloch",
       "evolvesTo": null,
       "primaryElement": "Fire",
       "level": "20",
@@ -8827,7 +8970,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 2d8 + 2 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 2d8 + 2 physical damage."
         },
         {
           "name": "Agidyne (16 SP, 1 action)",
@@ -8845,8 +8988,9 @@
       "background": "Moloch, or Molech, refers to a particular kind of sacrifice or possibly a god associated with fire, known first and foremost from the Bible. According to Leviticus, children were burned as an offering to Moloch. While Christian and Jewish tradition present Moloch as a demonic idol, an influential theory first formed in the the 1930s interprets the name as a term for a form of sacrifice analogous to the Punic mlk.[1] According to the Romans, child offerings were one of the main forms of worship of the \"african Saturn\" (Baal Hammon), the tutelary god of Carthage, leading to the assumption that mlk known from inscriptions from Punic sites is the rite of child sacrifice."
     },
     {
-      "name": "Seiryu",
-      "evolvesTo": "Kohryu",
+      "name": "seiryu",
+      "displayName": "Seiryu",
+      "evolvesTo": "kohryu",
       "primaryElement": "Ice",
       "level": "20",
       "arcana": "Councillor",
@@ -8881,7 +9025,7 @@
       "traits": [
         {
           "name": "God Maker",
-          "description": "It is in your presence and by your hand that your allies are enabled to forge legends. You gain the following benefits:\n \u2022 Whenever an allied creature within 120 feet, excluding yourself, rolls dice as part of a Trait\u2019s effect (such as Counter, Gaia Pact, Mastery of Magic, etc), you may reroll the dice once. You must use the new result."
+          "description": "It is in your presence and by your hand that your allies are enabled to forge legends. You gain the following benefits:\n\u2022 Whenever an allied creature within 120 feet, excluding yourself, rolls dice as part of a Trait\u2019s effect (such as Counter, Gaia Pact, Mastery of Magic, etc), you may reroll the dice once. You must use the new result."
         },
         {
           "name": "Relentless",
@@ -8891,7 +9035,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -4 to hit, range 5 ft., one target. \u000bHit: 2d8 + 3 physical damage."
+          "description": "Melee attack: -4 to hit, range 5 ft., one target.\nHit: 2d8 + 3 physical damage."
         },
         {
           "name": "Bufudyne (16 SP, 1 action)",
@@ -8906,11 +9050,12 @@
           "description": "You form a shimmering barrier that mirrors arcane assaults. Choose a creature within range (90 feet). That creature Repels the next attack they receive within the next 10 minutes that deals Fire, Ice, Electric, Wind, Psychic, Nuke, Bless, or Curse damage (see \u201cDamage\u201d)."
         }
       ],
-      "background": "The Qing Long, also known as Azure Dragon of the East or simply the Azure Dragon is one of the Four Symbols of the Chinese Constellation (Si Xiang) along with Xuan Wu, Zhu Que and Bai Hu. He is also one of the dragon gods who represent the mount or chthonic forces of the Five Forms of the Highest Deity in Chinese cosmology.\n It represents the East, spring, the color azure (green/blue) and the wood element. It is sometimes called the Azure Dragon of the East and is also known as Seiryu in Japanese, Cheong Yong in Korean and Thanh Long in Vietnamese. He has also been known as Blue-green Dragon, Green Dragon or the Blue Dragon.\n"
+      "background": "The Qing Long, also known as Azure Dragon of the East or simply the Azure Dragon is one of the Four Symbols of the Chinese Constellation (Si Xiang) along with Xuan Wu, Zhu Que and Bai Hu. He is also one of the dragon gods who represent the mount or chthonic forces of the Five Forms of the Highest Deity in Chinese cosmology.\n\nIt represents the East, spring, the color azure (green/blue) and the wood element. It is sometimes called the Azure Dragon of the East and is also known as Seiryu in Japanese, Cheong Yong in Korean and Thanh Long in Vietnamese. He has also been known as Blue-green Dragon, Green Dragon or the Blue Dragon."
     },
     {
-      "name": "Trumpeter",
-      "evolvesTo": "Attis",
+      "name": "trumpeter",
+      "displayName": "Trumpeter",
+      "evolvesTo": "attis",
       "primaryElement": "Support",
       "level": "20",
       "arcana": "Judgement",
@@ -8958,7 +9103,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 2d6 + 2 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 2d6 + 2 physical damage."
         },
         {
           "name": "Debilitate (18 SP, 1 action)",
@@ -8973,10 +9118,11 @@
           "description": "A plasma blast incinerates and irradiates a perfect sphere of foes, immolating them in the spot. Make a ranged attack against each creature within a 10-feet radius sphere centered at a point within range (-2 to hit, 20 feet). On a hit, they receive 3d8 + 5 nuke damage."
         }
       ],
-      "background": "The Trumpeter is based on one of the angels mentioned in the Book of Revelation of the New Testament. It is said that seven trumpets will be sounded by seven angels, and each trumpet signifies a different event or plague on Earth before the final moments leading to the Apocalypse.\n"
+      "background": "The Trumpeter is based on one of the angels mentioned in the Book of Revelation of the New Testament. It is said that seven trumpets will be sounded by seven angels, and each trumpet signifies a different event or plague on Earth before the final moments leading to the Apocalypse."
     },
     {
-      "name": "Forneus",
+      "name": "forneus",
+      "displayName": "Forneus",
       "evolvesTo": null,
       "primaryElement": "Psychic",
       "level": "21",
@@ -9014,7 +9160,7 @@
       "traits": [
         {
           "name": "Survival Trick",
-          "description": "With deceit and trickery, as well as resilience, you are able to avoid disaster. You gain the following benefits:\n \u2022 When you would be reduced to 0 hit points by a Hama or Mudo type Skill, or Door of Hades, you are reduced to 1 hit points instead.\n \u2022 When you would be reduced to 0 hit points by a hostile attack that is not a Hama or Mudo type Skill, or Door of Hades , you are reduced to 1 hit point instead. Once this ability is used, you cannot use it again until you fully recover in Reality. "
+          "description": "With deceit and trickery, as well as resilience, you are able to avoid disaster. You gain the following benefits:\n\u2022 When you would be reduced to 0 hit points by a Hama or Mudo type Skill, or Door of Hades, you are reduced to 1 hit points instead.\n\u2022 When you would be reduced to 0 hit points by a hostile attack that is not a Hama or Mudo type Skill, or Door of Hades , you are reduced to 1 hit point instead. Once this ability is used, you cannot use it again until you fully recover in Reality. "
         },
         {
           "name": "Relentless",
@@ -9024,7 +9170,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +6 to hit, range 5 ft., one target. \u000bHit: 2d4 + 4 physical damage."
+          "description": "Melee attack: +6 to hit, range 5 ft., one target.\nHit: 2d4 + 4 physical damage."
         },
         {
           "name": "Psiodyne (16 SP, 1 action)",
@@ -9032,17 +9178,18 @@
         },
         {
           "name": "Brain Jack (10 SP, 2 actions)",
-          "description": "You\u2019re not asking anymore. You use magic to directly weave into the hearts of foes, seizing control of the field. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range \u000b(+4 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Brainwash (see \u201cConditions\u201d)."
+          "description": "You\u2019re not asking anymore. You use magic to directly weave into the hearts of foes, seizing control of the field. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range\n(+4 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Brainwash (see \u201cConditions\u201d)."
         },
         {
           "name": "Masukunda (24 SP, 2 actions)",
           "description": "You bind and slow a group of enemies, allowing you to act faster than them. Choose up to six creatures within range (90 feet). Those creatures gain the effects of Sukunda."
         }
       ],
-      "background": "According to the writings in The Lesser Key of Solomon, Forneus is the thirtieth demonic spirit listed in Ars Goetia. He is a Great Marquis of Hell with twenty-nine legions under his command, partly of the order of angels and thrones, and appears as a sea monster. When summoned, he can make men well-versed in rhetoric, give them a good name, teach them foreign tongues, and make them trusted by friend and foe alike.\n His name seems to come from \"fornus\" (oven). He can take many different forms but mainly prefers his human form.\n"
+      "background": "According to the writings in The Lesser Key of Solomon, Forneus is the thirtieth demonic spirit listed in Ars Goetia. He is a Great Marquis of Hell with twenty-nine legions under his command, partly of the order of angels and thrones, and appears as a sea monster. When summoned, he can make men well-versed in rhetoric, give them a good name, teach them foreign tongues, and make them trusted by friend and foe alike.\n\nHis name seems to come from \"fornus\" (oven). He can take many different forms but mainly prefers his human form."
     },
     {
-      "name": "Hanuman",
+      "name": "hanuman",
+      "displayName": "Hanuman",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "21",
@@ -9080,7 +9227,7 @@
       "traits": [
         {
           "name": "Attack Master",
-          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action."
+          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action."
         },
         {
           "name": "Endure",
@@ -9090,11 +9237,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +4 to hit, range 5 ft., one target. \u000bHit: 2d6 + 4 physical damage."
+          "description": "Melee attack: +4 to hit, range 5 ft., one target.\nHit: 2d6 + 4 physical damage."
         },
         {
           "name": "Deathbound (12 SP, 2 actions)",
-          "description": "Hands of fallen warriors emerge from the soil to grasp and strike at foes. Make two melee attacks against each creature within a 20-foot sphere centered at a point within range (+4 to hit, 20 feet). For each hit, a creature receives \u000b2d8 + 4 physical damage."
+          "description": "Hands of fallen warriors emerge from the soil to grasp and strike at foes. Make two melee attacks against each creature within a 20-foot sphere centered at a point within range (+4 to hit, 20 feet). For each hit, a creature receives\n2d8 + 4 physical damage."
         },
         {
           "name": "Matarunda (24 SP, 2 actions)",
@@ -9105,10 +9252,11 @@
           "description": "Golden light of obstinance heightens an ally\u2019s ability to deliver punishment. Choose a creature within range (90 feet). For 1 minute, attacks the creature makes score a Critical hit if the result of each d6 is a 5 or higher."
         }
       ],
-      "background": "Hanuman, also known as Anjaneya (son of Anjana, an Apsara), is son of the wind god Vayu. He is as tall as a mountain, his face shines scarlet, and he has a long tail. He is the hero of the monkey army. His roar is like thunder, he is able to transform into anything, fly, and has great strength.\n He is one of the most important characters in the epic Ramayana where he performs many heroic feats. He is most famously known for aiding prince Rama (one of the avatars of Vishnu) in defeating the demon king Ravana by leading an army of monkeys.\n"
+      "background": "Hanuman, also known as Anjaneya (son of Anjana, an Apsara), is son of the wind god Vayu. He is as tall as a mountain, his face shines scarlet, and he has a long tail. He is the hero of the monkey army. His roar is like thunder, he is able to transform into anything, fly, and has great strength.\n\nHe is one of the most important characters in the epic Ramayana where he performs many heroic feats. He is most famously known for aiding prince Rama (one of the avatars of Vishnu) in defeating the demon king Ravana by leading an army of monkeys."
     },
     {
-      "name": "Kali",
+      "name": "kali",
+      "displayName": "Kali",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "21",
@@ -9157,7 +9305,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Brave Blade (10 HP, 1 action)",
@@ -9169,14 +9317,15 @@
         },
         {
           "name": "Bloodbath (16 HP, 2 actions)",
-          "description": "Ribbons of dark blades lash out, hacking a field into terrifying ribbons. Make a melee attack against each creature within a 20-foot sphere centered at a point within range (-2 to hit, 20 feet). A creature hit by this attack receives \u000b4d8 + 5 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Fear (see \u201cConditions'')."
+          "description": "Ribbons of dark blades lash out, hacking a field into terrifying ribbons. Make a melee attack against each creature within a 20-foot sphere centered at a point within range (-2 to hit, 20 feet). A creature hit by this attack receives\n4d8 + 5 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Fear (see \u201cConditions'')."
         }
       ],
-      "background": "Kali is a Hindu goddess associated with death, time and destruction. The name Kali means \"black,\" but has by folk etymology come to mean \"force of time (kala).\" The name \"Kali\" means \"black one\" and is derived from the word \"kala\" (black), but has also come to mean \"goddess of time\". Despite her negative connotations, she is today considered the goddess of time and change. Although sometimes presented as dark and violent, her earliest incarnation as a figure of annihilation still has some influence. More complex Tantric beliefs sometimes extend her role so far as to be the \"ultimate reality\" or Brahman. She is also revered as Bhavatarini (literally \"redeemer of the universe\"). Comparatively recent devotional movements largely conceive Kali as a benevolent mother goddess.\n"
+      "background": "Kali is a Hindu goddess associated with death, time and destruction. The name Kali means \"black,\" but has by folk etymology come to mean \"force of time (kala).\" The name \"Kali\" means \"black one\" and is derived from the word \"kala\" (black), but has also come to mean \"goddess of time\". Despite her negative connotations, she is today considered the goddess of time and change. Although sometimes presented as dark and violent, her earliest incarnation as a figure of annihilation still has some influence. More complex Tantric beliefs sometimes extend her role so far as to be the \"ultimate reality\" or Brahman. She is also revered as Bhavatarini (literally \"redeemer of the universe\"). Comparatively recent devotional movements largely conceive Kali as a benevolent mother goddess."
     },
     {
-      "name": "Loki",
-      "evolvesTo": "Odin",
+      "name": "loki",
+      "displayName": "Loki",
+      "evolvesTo": "odin",
       "primaryElement": "Physical",
       "level": "21",
       "arcana": "Justice",
@@ -9211,7 +9360,7 @@
       "traits": [
         {
           "name": "Ingenious Spirit",
-          "description": "Your tactical supremacy is without question, navigating the optimal path for you and your allies. You gain the following benefits:\n \u2022 Whenever you or a creature within 60 feet of you uses a Support, you may roll 1d4. On a 4, the Spell Point cost of the Skill is halved, rounded down, to a \u000bminimum of 1.\n \u2022 The first Analysis action you perform during a turn does not cost an action."
+          "description": "Your tactical supremacy is without question, navigating the optimal path for you and your allies. You gain the following benefits:\n\u2022 Whenever you or a creature within 60 feet of you uses a Support, you may roll 1d4. On a 4, the Spell Point cost of the Skill is halved, rounded down, to a\nminimum of 1.\n\u2022 The first Analysis action you perform during a turn does not cost an action."
         },
         {
           "name": "Fortify Spirit",
@@ -9221,7 +9370,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Laevateinn (10 HP, 1 action)",
@@ -9233,14 +9382,15 @@
         },
         {
           "name": "Riot Gun (12 HP, 2 actions)",
-          "description": "A shower of piercing shots rain from the heavens above, turning foes into ribbons. Make a ranged attack against each creature within a 20-feet sphere, centered at a point within range (-2 to hit, 60 feet). On a hit, the creature receives \u000b5d10 + 5 gun damage."
+          "description": "A shower of piercing shots rain from the heavens above, turning foes into ribbons. Make a ranged attack against each creature within a 20-feet sphere, centered at a point within range (-2 to hit, 60 feet). On a hit, the creature receives\n5d10 + 5 gun damage."
         }
       ],
-      "background": "Loki was the trickster god who was also known to be a god of mischief, magic and fire in Norse Mythology. His mischievous nature was such that he even managed to slither his way into becoming one of the Norse deities. He is son of F\u00e1rbauti, a j\u00f6tunn, and Laufey, a lesser known goddess and is the blood-brother of Odin, with his two biological brothers being Helblindi and B\u00fdleistr. With the onset of Ragnar\u00f6k, Loki is foretold to encounter the god Heimdallr and kill him, dying in the process.\n"
+      "background": "Loki was the trickster god who was also known to be a god of mischief, magic and fire in Norse Mythology. His mischievous nature was such that he even managed to slither his way into becoming one of the Norse deities. He is son of F\u00e1rbauti, a j\u00f6tunn, and Laufey, a lesser known goddess and is the blood-brother of Odin, with his two biological brothers being Helblindi and B\u00fdleistr. With the onset of Ragnar\u00f6k, Loki is foretold to encounter the god Heimdallr and kill him, dying in the process."
     },
     {
-      "name": "Thor",
-      "evolvesTo": "Odin",
+      "name": "thor",
+      "displayName": "Thor",
+      "evolvesTo": "odin",
       "primaryElement": "Electric",
       "level": "21",
       "arcana": "Chariot",
@@ -9277,7 +9427,7 @@
       "traits": [
         {
           "name": "Heat Up",
-          "description": "You are hot to trot when the need arises. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll."
+          "description": "You are hot to trot when the need arises. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll."
         },
         {
           "name": "Elemental Amp (Electric)",
@@ -9287,11 +9437,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Wild Thunder (24 SP, 2 actions)",
-          "description": "You unfurl a pure, ungrounded storm of lightning that vaporizes most upon a field of foes with a high chance of Shock. Make a ranged attack against each creature within a 20-feet sphere centered at a point within range \u000b(-2 to hit, 20 feet). On a hit, they receive 7d8 + 4 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
+          "description": "You unfurl a pure, ungrounded storm of lightning that vaporizes most upon a field of foes with a high chance of Shock. Make a ranged attack against each creature within a 20-feet sphere centered at a point within range\n(-2 to hit, 20 feet). On a hit, they receive 7d8 + 4 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
         },
         {
           "name": "Megaton Raid (8 HP, 1 action)",
@@ -9302,10 +9452,11 @@
           "description": "You heighten your resolve and unleash brutality with extraordinary support. You gain the effects of Concentrate and Power Charge."
         }
       ],
-      "background": "Thor (Old Norse: \u00de\u00f3rr), also known as Thor Odinson, is the red-haired son of Odin and Jord, and is the god of lightning, thunder, storms, sacred groves and trees in Norse mythology and Germanic paganism. Thor is one of the most powerful gods and uses his superior power to protect Asgard and Midgard. Due to his lust for battle and incredible prowess, Thor is also portrayed as a war god and also an agricultural god due to his status as a weather deity that aids in the growth of crops. His belt Mejingjard doubles his strength and lightning flashes every time he throws his trusty hammer, Mj\u00f6lnir.\n"
+      "background": "Thor (Old Norse: \u00de\u00f3rr), also known as Thor Odinson, is the red-haired son of Odin and Jord, and is the god of lightning, thunder, storms, sacred groves and trees in Norse mythology and Germanic paganism. Thor is one of the most powerful gods and uses his superior power to protect Asgard and Midgard. Due to his lust for battle and incredible prowess, Thor is also portrayed as a war god and also an agricultural god due to his status as a weather deity that aids in the growth of crops. His belt Mejingjard doubles his strength and lightning flashes every time he throws his trusty hammer, Mj\u00f6lnir."
     },
     {
-      "name": "Yamata-no-Orochi",
+      "name": "yamata-no-orochi",
+      "displayName": "Yamata-no-Orochi",
       "evolvesTo": null,
       "primaryElement": "Ice",
       "level": "21",
@@ -9343,7 +9494,7 @@
       "traits": [
         {
           "name": "Cold-Blooded",
-          "description": "With reptilian cruelty, you freeze a foe. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with Freeze (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "With reptilian cruelty, you freeze a foe. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with Freeze (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         },
         {
           "name": "Elemental Amp (Ice)",
@@ -9353,7 +9504,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Diamond Dust (24 SP, 1 action)",
@@ -9368,10 +9519,11 @@
           "description": "A demonic dance swirls about and punctures foes in vital points. Make a melee attack against up to six creatures within range (-2 to hit, 20 feet) . A creature hit by this attack receives 2d8 + 5 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Rage (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Yamata no Orochi is an eight-headed and eight-tailed serpent dragon with an enormous body that reaches across eight valleys and eight hills that appears in Japanese lore.\n When Susano-o is in exile from the heavens, he finds a couple and their daughter crying by the river. They explain their sadness to him, that every year, the Orochi comes to devour one of their daughters. This year, they must give up their eighth and final daughter, Kushinada-Hime.\n"
+      "background": "Yamata no Orochi is an eight-headed and eight-tailed serpent dragon with an enormous body that reaches across eight valleys and eight hills that appears in Japanese lore.\n\nWhen Susano-o is in exile from the heavens, he finds a couple and their daughter crying by the river. They explain their sadness to him, that every year, the Orochi comes to devour one of their daughters. This year, they must give up their eighth and final daughter, Kushinada-Hime."
     },
     {
-      "name": "Atavaka",
+      "name": "atavaka",
+      "displayName": "Atavaka",
       "evolvesTo": null,
       "primaryElement": "Healing",
       "level": "22",
@@ -9410,7 +9562,7 @@
       "traits": [
         {
           "name": "Attack Master",
-          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action. "
+          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action. "
         },
         {
           "name": "Savior Bloodline",
@@ -9420,7 +9572,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Mediarahan (18 SP, 2 actions)",
@@ -9435,11 +9587,12 @@
           "description": "A pillar-shaped conflagration erupts, spiraling about and enveloping a foe. Make a ranged attack against a creature within range (-2 to hit, 30 feet). On a hit, they receive 4d8 + 3 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Atavaka (\"lord of the forest\" in Sanskrit), or Daigensui Myo-O (\u5927\u5143\u5e25\u660e\u738b) in Japanese, used to be a child-eating demon until he received Buddha's enlightenment. He then became one of the Yaksha Kings and vassal to Bishamonten, as well as the protector god of the southwest.\n"
+      "background": "Atavaka (\"lord of the forest\" in Sanskrit), or Daigensui Myo-O (\u5927\u5143\u5e25\u660e\u738b) in Japanese, used to be a child-eating demon until he received Buddha's enlightenment. He then became one of the Yaksha Kings and vassal to Bishamonten, as well as the protector god of the southwest."
     },
     {
-      "name": "Bishamonten",
-      "evolvesTo": "Baal",
+      "name": "bishamonten",
+      "displayName": "Bishamonten",
+      "evolvesTo": "baal",
       "primaryElement": "Nuke",
       "level": "22",
       "arcana": "Hierophant",
@@ -9487,7 +9640,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Freidyne (16 SP, 1 action)",
@@ -9499,14 +9652,15 @@
         },
         {
           "name": "Deadly Fury (13 HP, 1 action)",
-          "description": "A horizontal slash with blinding speed strikes the opponent with godly precision and severing force. Make a melee attack against a creature within range \u000b(-2 to hit, 10 feet). On a hit, the creature receives 6d10 + 5 physical damage. If this Skill is used with an action granted by a Baton Pass, the damage dealt is doubled."
+          "description": "A horizontal slash with blinding speed strikes the opponent with godly precision and severing force. Make a melee attack against a creature within range\n(-2 to hit, 10 feet). On a hit, the creature receives 6d10 + 5 physical damage. If this Skill is used with an action granted by a Baton Pass, the damage dealt is doubled."
         }
       ],
-      "background": "Also known as Tamonten and Vaishravana in Buddhist lore, he is the strongest of the Heavenly Kings. He protects the North and is the god of war.\n"
+      "background": "Also known as Tamonten and Vaishravana in Buddhist lore, he is the strongest of the Heavenly Kings. He protects the North and is the god of war."
     },
     {
-      "name": "Mot",
-      "evolvesTo": "Lucifer",
+      "name": "mot",
+      "displayName": "Mot",
+      "evolvesTo": "lucifer",
       "primaryElement": "Almighty",
       "level": "22",
       "arcana": "Death",
@@ -9555,11 +9709,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -4 to hit, range 5 ft., one target. \u000bHit: 2d8 + 3 physical damage."
+          "description": "Melee attack: -4 to hit, range 5 ft., one target.\nHit: 2d8 + 3 physical damage."
         },
         {
           "name": "Megidolaon (36 SP, 2 actions)",
-          "description": "A flash of light. A singularity instantly expands, as a reality-busting sphere of destructive energy emerges from the ground, blinding and erasing all. Make a ranged attack against each creature within a 20-foot radius sphere centered at a point within range \u000b(-2 to hit, 20 feet). On a hit, a creature receives 7d8 + 5 almighty damage."
+          "description": "A flash of light. A singularity instantly expands, as a reality-busting sphere of destructive energy emerges from the ground, blinding and erasing all. Make a ranged attack against each creature within a 20-foot radius sphere centered at a point within range\n(-2 to hit, 20 feet). On a hit, a creature receives 7d8 + 5 almighty damage."
         },
         {
           "name": "Concentrate (15 SP, 1 action)",
@@ -9570,10 +9724,11 @@
           "description": "A portal to despair yawns below a foe\u2019s feet, only to flood them in a wave of pure hatred. Make a ranged attack against a creature within range (-2 to hit, 60 feet). On a hit, they receive 4d8 + 5 curse damage."
         }
       ],
-      "background": "Mot, also known as Mavet, is the Canaanite personification of death, also associated with infertility, drought and the Underworld. He \"lives in the throne city which goes by the name Hemry, a pit is his throne, and Filth is the land of his heritage.\" According to another text, he holds \"the scepter of widowhood\" and \"the scepter of bereavement.\" He is prominently featured in the mythology of Ugarit, but some mentions survive in later Phoenician texts as well.\n A few references in the Bible also appear to be a memory of Mot, such as vague mentions of seemingly personified death in the books of Hosea, Habakkuk and Jeremiah. Evidence from Ugarit indicates Mot was not worshiped, and he isn't attested in theophoric names; he was a demonic personification of an abstract concept rather than a god.[1] This makes him distinct from other Semitic figures associated with the afterlife, such as Nergal.\n"
+      "background": "Mot, also known as Mavet, is the Canaanite personification of death, also associated with infertility, drought and the Underworld. He \"lives in the throne city which goes by the name Hemry, a pit is his throne, and Filth is the land of his heritage.\" According to another text, he holds \"the scepter of widowhood\" and \"the scepter of bereavement.\" He is prominently featured in the mythology of Ugarit, but some mentions survive in later Phoenician texts as well.\n\nA few references in the Bible also appear to be a memory of Mot, such as vague mentions of seemingly personified death in the books of Hosea, Habakkuk and Jeremiah. Evidence from Ugarit indicates Mot was not worshiped, and he isn't attested in theophoric names; he was a demonic personification of an abstract concept rather than a god.[1] This makes him distinct from other Semitic figures associated with the afterlife, such as Nergal."
     },
     {
-      "name": "Nyarlathotep",
+      "name": "nyarlathotep",
+      "displayName": "Nyarlathotep",
       "evolvesTo": null,
       "primaryElement": "Almighty",
       "level": "22",
@@ -9610,7 +9765,7 @@
       "traits": [
         {
           "name": "Call of Chaos",
-          "description": "You can induce yourself and others with twisted power borne from madness. You gain the following benefits:\n \u2022 As 1 action, you induce extreme stress and psychosis upon yourself. If you do, for the next 1 minute, all damage dice roll for attacks made by you and against you are treated as their maximum result.\n \u2022 As 2 actions, you induce extreme stress and psychosis upon others. If you do, choose up to six creatures within 60 feet of you. For the next 1 minute, all damage dice roll for attacks made by those creatures and against those creatures are treated as their maximum result."
+          "description": "You can induce yourself and others with twisted power borne from madness. You gain the following benefits:\n\u2022 As 1 action, you induce extreme stress and psychosis upon yourself. If you do, for the next 1 minute, all damage dice roll for attacks made by you and against you are treated as their maximum result.\n\u2022 As 2 actions, you induce extreme stress and psychosis upon others. If you do, choose up to six creatures within 60 feet of you. For the next 1 minute, all damage dice roll for attacks made by those creatures and against those creatures are treated as their maximum result."
         },
         {
           "name": "Unshaken Will",
@@ -9620,11 +9775,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Crawling Chaos (32 SP, 2 actions)",
-          "description": "Eldritch tendrils and forces emerge from all sides, plunging those unlucky to be caught in the rift into amnesiatic agony. Make a melee attack against each creature within range \u000b(-2 to hit, 30 feet). On a hit, a creature receives 3d8 + Magic almighty damage. If the result of all d6s in the attack roll are a 3 or higher, a creature is inflicted with Forget (see \u201cConditions\u201d)."
+          "description": "Eldritch tendrils and forces emerge from all sides, plunging those unlucky to be caught in the rift into amnesiatic agony. Make a melee attack against each creature within range\n(-2 to hit, 30 feet). On a hit, a creature receives 3d8 + Magic almighty damage. If the result of all d6s in the attack roll are a 3 or higher, a creature is inflicted with Forget (see \u201cConditions\u201d)."
         },
         {
           "name": "Mudoon (12 SP, 1 action)",
@@ -9635,10 +9790,11 @@
           "description": "You form a physical shield that blocks all kinetic force from penetrating. Choose a creature within range (90 feet). That creature Repels the next attack they receive within the next 10 minutes that deals Physical or Gun damage (see \u201cDamage\u201d)."
         }
       ],
-      "background": "Nyarlathotep was known to many as The Crawling Chaos, The God of a Thousand Forms, The Dweller in Darkness, The Faceless God, The Floating Horror, The Haunter of the Dark or many others, is an Outer God in the Cthulhu Mythos. He is the spawn of Azathoth. Like many of the well known Old Ones, he was created by H. P. Lovecraft.\n Nyarlathotep differs from the other deities in the Mythos in a number of ways. Most of the Outer Gods are exiled to the stars, like Yog-Sothoth and Azathoth, and most of the Great Old Ones are sleeping and dreaming like Cthulhu; Nyarlathotep, however, is active and frequently walks the Earth, actively seeking to agitate the universe into madness, woe, and discord. He has been known as a manipulative, charismatic and cruel entity who enjoys bringing chaos to the many worlds he walks. He has \"a thousand\" other forms and manifestations, most reputed to be quite horrific and sanity-blasting."
+      "background": "Nyarlathotep was known to many as The Crawling Chaos, The God of a Thousand Forms, The Dweller in Darkness, The Faceless God, The Floating Horror, The Haunter of the Dark or many others, is an Outer God in the Cthulhu Mythos. He is the spawn of Azathoth. Like many of the well known Old Ones, he was created by H. P. Lovecraft.\n\nNyarlathotep differs from the other deities in the Mythos in a number of ways. Most of the Outer Gods are exiled to the stars, like Yog-Sothoth and Azathoth, and most of the Great Old Ones are sleeping and dreaming like Cthulhu; Nyarlathotep, however, is active and frequently walks the Earth, actively seeking to agitate the universe into madness, woe, and discord. He has been known as a manipulative, charismatic and cruel entity who enjoys bringing chaos to the many worlds he walks. He has \"a thousand\" other forms and manifestations, most reputed to be quite horrific and sanity-blasting."
     },
     {
-      "name": "Oberon",
+      "name": "oberon",
+      "displayName": "Oberon",
       "evolvesTo": null,
       "primaryElement": "Ailment",
       "level": "22",
@@ -9676,7 +9832,7 @@
       "traits": [
         {
           "name": "Static Electricity",
-          "description": "An overabundance of electrical power primes a foe for paralysis. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with Shock (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "An overabundance of electrical power primes a foe for paralysis. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with Shock (see \u201cConditions\u201d), flip a coin. If heads, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         },
         {
           "name": "Elemental Amp (Electric)",
@@ -9686,11 +9842,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: range 5 ft., one target. \u000bHit: 2d4 + 4 physical damage."
+          "description": "Melee attack: range 5 ft., one target.\nHit: 2d4 + 4 physical damage."
         },
         {
           "name": "Ziodyne (16 SP, 1 action)",
-          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (-2 to hit, 30 feet). On a hit, they receive \u000b6d8 + 4 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
+          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (-2 to hit, 30 feet). On a hit, they receive\n6d8 + 4 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
         },
         {
           "name": "Nocturnal Flash (10 SP, 2 actions)",
@@ -9701,10 +9857,11 @@
           "description": "A wellspring of youth and vigor comes forth, nurturing an ally with new health. Choose a creature that is knocked out within range (90 feet). That creature regains all of their missing hit points."
         }
       ],
-      "background": "Oberon is the high king of the Fae and the husband of Titania (or Mab), the high queen of the Fae. He rules over the moonlight, dreams and all fairy rites. Some depictions say he is in charge of only the Seelie Court, but other depictions make him the leader of the entire fairyland. Although he has the face of a handsome young man, a curse has made him no taller than a young child that he received shortly after birth. However, the curse gives him eternal beauty.\n"
+      "background": "Oberon is the high king of the Fae and the husband of Titania (or Mab), the high queen of the Fae. He rules over the moonlight, dreams and all fairy rites. Some depictions say he is in charge of only the Seelie Court, but other depictions make him the leader of the entire fairyland. Although he has the face of a handsome young man, a curse has made him no taller than a young child that he received shortly after birth. However, the curse gives him eternal beauty."
     },
     {
-      "name": "Quetzacoatl",
+      "name": "quetzacoatl",
+      "displayName": "Quetzacoatl",
       "evolvesTo": null,
       "primaryElement": "Wind",
       "level": "22",
@@ -9752,26 +9909,27 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 2d6 + 4 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 2d6 + 4 physical damage."
         },
         {
           "name": "Garudyne (7 SP, 1 action)",
-          "description": "A maelstrom wraps around a target, buffeting them into oblivion. Make a ranged attack against a creature within range \u000b(-2 to hit, 90 feet). On a hit, they receive 6d8 + 4 wind damage"
+          "description": "A maelstrom wraps around a target, buffeting them into oblivion. Make a ranged attack against a creature within range\n(-2 to hit, 90 feet). On a hit, they receive 6d8 + 4 wind damage"
         },
         {
           "name": "Memory Blow (6 HP, 2 actions)",
-          "description": "You focus your inner strength, and unleash it as a thunderous burst from yourself. Make a melee attack against each creature within a 20-foot sphere centered at a point within range \u000b(-2 to hit, 20 feet). A creature hit by this attack receives 1d8 + 4 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Forget (see \u201cConditions\u201d)."
+          "description": "You focus your inner strength, and unleash it as a thunderous burst from yourself. Make a melee attack against each creature within a 20-foot sphere centered at a point within range\n(-2 to hit, 20 feet). A creature hit by this attack receives 1d8 + 4 physical damage. If the result of all d6s in the attack roll are a 4 or higher, a creature is inflicted with Forget (see \u201cConditions\u201d)."
         },
         {
           "name": "Hamaon (12 SP, 1 action)",
-          "description": "Divine will and an excess of banishing rights and rituals consecrate the creature\u2019s space, purging it of evil and existence. Choose a creature within range and make a ranged attack against them \u000b(-2 to hit, 90 feet). On a hit, if the result of each d6 is 3 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Bless. This Skill provokes a One More if the target is weak to Bless."
+          "description": "Divine will and an excess of banishing rights and rituals consecrate the creature\u2019s space, purging it of evil and existence. Choose a creature within range and make a ranged attack against them\n(-2 to hit, 90 feet). On a hit, if the result of each d6 is 3 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Bless. This Skill provokes a One More if the target is weak to Bless."
         }
       ],
-      "background": "Quetzalcoatl is an Aztec sky and creator god along with representing the Sun, the element air, wind, and learning. The name is a combination of quetzal, a brightly colored Mesoamerican bird, and coatl, meaning serpent. The name was also taken on by various ancient leaders.\n Due to their cyclical view of time and the tendency of leaders to revise histories to support their rule, many events and attributes attributed to Quetzalcoatl are exceedingly difficult to separate from the political leaders that took this name on themselves. Quetzalcoatl is often referred to as The Feathered Serpent, connected to the planet Venus and was also the patron god of the Aztec priesthood, of learning and knowledge.\n"
+      "background": "Quetzalcoatl is an Aztec sky and creator god along with representing the Sun, the element air, wind, and learning. The name is a combination of quetzal, a brightly colored Mesoamerican bird, and coatl, meaning serpent. The name was also taken on by various ancient leaders.\n\nDue to their cyclical view of time and the tendency of leaders to revise histories to support their rule, many events and attributes attributed to Quetzalcoatl are exceedingly difficult to separate from the political leaders that took this name on themselves. Quetzalcoatl is often referred to as The Feathered Serpent, connected to the planet Venus and was also the patron god of the Aztec priesthood, of learning and knowledge."
     },
     {
-      "name": "Thanatos",
-      "evolvesTo": "Messiah",
+      "name": "thanatos",
+      "displayName": "Thanatos",
+      "evolvesTo": "messiah",
       "primaryElement": "Almighty",
       "level": "22",
       "arcana": "Death",
@@ -9808,17 +9966,17 @@
       "traits": [
         {
           "name": "Iron Heart",
-          "description": "You are the emboldened, steel bulwark that provides foundation for your team. You gain the following benefits:\n \u2022 The Spell Point cost of Skills used with actions granted to you by a Baton Pass are halved, rounded down\n (min 1).\n \u2022 Whenever you perform a Baton Pass to grant an extra action to an ally, you regain 1d8 + half your level Spell Points (min 1)."
+          "description": "You are the emboldened, steel bulwark that provides foundation for your team. You gain the following benefits:\n\u2022 The Spell Point cost of Skills used with actions granted to you by a Baton Pass are halved, rounded down\n(min 1).\n\u2022 Whenever you perform a Baton Pass to grant an extra action to an ally, you regain 1d8 + half your level Spell Points (min 1)."
         },
         {
           "name": "Omen",
-          "description": "You are a living embodiment of purgation. You gain the following benefits:\n \u2022 You have advantage on attacks made for Hama, Hamaon, Samsara, Mudo, Mudoon,  Die for Me!, and Door of Hades.\n \u2022 Whenever you make an attack roll for Hama, Hamaon, Samsara, Mudo, Mudoon,  Die for Me!, or Door of Hades, you may reroll any of the dice once. You must use the new result. "
+          "description": "You are a living embodiment of purgation. You gain the following benefits:\n\u2022 You have advantage on attacks made for Hama, Hamaon, Samsara, Mudo, Mudoon,  Die for Me!, and Door of Hades.\n\u2022 Whenever you make an attack roll for Hama, Hamaon, Samsara, Mudo, Mudoon,  Die for Me!, or Door of Hades, you may reroll any of the dice once. You must use the new result. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 2d6 + 4 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 2d6 + 4 physical damage."
         },
         {
           "name": "Door of Hades (36 SP, 2 actions)",
@@ -9833,10 +9991,11 @@
           "description": "A portal to despair yawns below a foe\u2019s feet, only to flood them in a wave of pure hatred. Make a ranged attack against a creature within range (+3 to hit, 60 feet). On a hit, they receive 4d8 + 5 curse damage."
         }
       ],
-      "background": "Thanatos is the personification and god of death and mortality in Greek mythology. He is commonly known as a harbinger of peaceful death, bringing the eternal sleep of death to the world while more violent gods were responsible for harsher death. He did not play a major part in Greek mythology and rarely appeared in any stories, as he was mostly displaced by Hades, the god of the underworld.\n"
+      "background": "Thanatos is the personification and god of death and mortality in Greek mythology. He is commonly known as a harbinger of peaceful death, bringing the eternal sleep of death to the world while more violent gods were responsible for harsher death. He did not play a major part in Greek mythology and rarely appeared in any stories, as he was mostly displaced by Hades, the god of the underworld."
     },
     {
-      "name": "Black Frost",
+      "name": "black-frost",
+      "displayName": "Black Frost",
       "evolvesTo": null,
       "primaryElement": "Ice",
       "level": "23",
@@ -9885,7 +10044,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: range 5 ft., one target. \u000bHit: 2d4 + 4 physical damage."
+          "description": "Melee attack: range 5 ft., one target.\nHit: 2d4 + 4 physical damage."
         },
         {
           "name": "Diamond Dust (12 SP, 1 action)",
@@ -9900,11 +10059,12 @@
           "description": "You seize the opportunity that fate has laid before you, making this strike count. Make a melee attack against a creature within range (-2 to hit, 10 feet). A creature hit by this attack receives 2d10 + 4 physical damage. This Skill scores a Critical hit if the result of each d6 in its attack roll is 5 or higher."
         }
       ],
-      "background": "Black Frost is Atlus' evil rendition of the more good-spirited demon Jack Frost. The word ja'aku in its Japanese name when written in kanji (\u90aa\u60aa) means \"wicked\" or \"evil,\" hence its dark characteristics.\n In short, Black Frost is a Jack Frost who remembered it was a demon.\n"
+      "background": "Black Frost is Atlus' evil rendition of the more good-spirited demon Jack Frost. The word ja'aku in its Japanese name when written in kanji (\u90aa\u60aa) means \"wicked\" or \"evil,\" hence its dark characteristics.\n\nIn short, Black Frost is a Jack Frost who remembered it was a demon."
     },
     {
-      "name": "Byakhee",
-      "evolvesTo": "Hastur",
+      "name": "byakhee",
+      "displayName": "Byakhee",
+      "evolvesTo": "hastur",
       "primaryElement": "Fire",
       "level": "23",
       "arcana": "Moon",
@@ -9946,13 +10106,13 @@
         },
         {
           "name": "Gaia Blessing",
-          "description": "With your blessing, you ride into battle and crush enemies underneath, heightening the elemental powers around you. Additionally, your Persona/Demonic abilities manifest in a vehicular way:\n \u2022 Whenever you or a creature within 30 feet of you attempts to inflict a target with Burn, Shock, or Freeze, you may roll 1d4. On a 4, the Condition is successfully inflicted. "
+          "description": "With your blessing, you ride into battle and crush enemies underneath, heightening the elemental powers around you. Additionally, your Persona/Demonic abilities manifest in a vehicular way:\n\u2022 Whenever you or a creature within 30 feet of you attempts to inflict a target with Burn, Shock, or Freeze, you may roll 1d4. On a 4, the Condition is successfully inflicted. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Agidyne (16 SP, 1 action)",
@@ -9960,17 +10120,18 @@
         },
         {
           "name": "Stagnant Air (5 SP, 2 actions)",
-          "description": "?The air becomes riddled and ripe with foul energy, Disease and wretched magic begins to flow and infest more easily. This Skill affects all creatures within range, including yourself and allies \u000b(30 feet). For the next 10 minutes, whenever an affected creature would be potentially inflicted with a Condition, flip a coin. If heads, the Condition is successfully inflicted. This effect is in addition to the original means by which they are inflicted by the Condition."
+          "description": "?The air becomes riddled and ripe with foul energy, Disease and wretched magic begins to flow and infest more easily. This Skill affects all creatures within range, including yourself and allies\n(30 feet). For the next 10 minutes, whenever an affected creature would be potentially inflicted with a Condition, flip a coin. If heads, the Condition is successfully inflicted. This effect is in addition to the original means by which they are inflicted by the Condition."
         },
         {
           "name": "Heat Riser (18 SP, 1 action)",
           "description": "The aid of magic releases an ally\u2019s limiters, allowing them to fight at full potential. Choose a creature within range (90 feet). This creature gains the effects of Tarukaja, Rakukaja, and Sukukaja."
         }
       ],
-      "background": "The Byakhee, or the Biyarky, are eldritch servants of the Great Old One Hastur the unspeakable. They are a race of three meter high hybrid creatures made of ordinary matter that live in interstellar space. A hybrid who is neither completely crows, nor moles, nor buzzards, nor ants, nor vampire bats, nor decomposed human beings, can neither be fully perceived nor remembered by a sane person.\n They can travel through space and carry a rider, but the rider must have something capable of protecting them from the cold and vacuum of space. They can be summoned to Earth to carry out tasks or act as steeds. Byakhee need not breathe, and do not appear on Earth unless summoned by sorcerers or called by their master, Hastur. Still, there is a chance that they will go down to any planet if they need to hunt for food.\n"
+      "background": "The Byakhee, or the Biyarky, are eldritch servants of the Great Old One Hastur the unspeakable. They are a race of three meter high hybrid creatures made of ordinary matter that live in interstellar space. A hybrid who is neither completely crows, nor moles, nor buzzards, nor ants, nor vampire bats, nor decomposed human beings, can neither be fully perceived nor remembered by a sane person.\n\nThey can travel through space and carry a rider, but the rider must have something capable of protecting them from the cold and vacuum of space. They can be summoned to Earth to carry out tasks or act as steeds. Byakhee need not breathe, and do not appear on Earth unless summoned by sorcerers or called by their master, Hastur. Still, there is a chance that they will go down to any planet if they need to hunt for food."
     },
     {
-      "name": "Dominion",
+      "name": "dominion",
+      "displayName": "Dominion",
       "evolvesTo": null,
       "primaryElement": "Bless",
       "level": "23",
@@ -10020,7 +10181,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: range 5 ft., one target. \u000bHit: 2d4 + 3 physical damage."
+          "description": "Melee attack: range 5 ft., one target.\nHit: 2d4 + 3 physical damage."
         },
         {
           "name": "Kougaon (8 SP, 1 action)",
@@ -10035,10 +10196,11 @@
           "description": "A psionic abyss springs forth from your fingertips, draining the memories of a field of foes. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range (-2 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Forget (see \u201cConditions\u201d)."
         }
       ],
-      "background": "In the Christian hierarchy of Angels, Dominions, also known as Lordships, are part of the second sphere and are said to watch over nations and regulate the duties of lesser angels. In Moses Maimonides' hierarchy of angels, according to Jewish lore, they are Hashmallim (the fourth rank of angels) and are mentioned briefly in the Hebrew version of the Book of Ezekiel.\n In Asian regions, their title translates to \"Angel of Lord\" (\u4e3b\u5929\u4f7f, Shutenshi)?, or less commonly and ambiguous with Principality, \"Angel of Authority\" (\u6b0a\u5929\u4f7f, Kentenshi or Gontenshi)?."
+      "background": "In the Christian hierarchy of Angels, Dominions, also known as Lordships, are part of the second sphere and are said to watch over nations and regulate the duties of lesser angels. In Moses Maimonides' hierarchy of angels, according to Jewish lore, they are Hashmallim (the fourth rank of angels) and are mentioned briefly in the Hebrew version of the Book of Ezekiel.\n\nIn Asian regions, their title translates to \"Angel of Lord\" (\u4e3b\u5929\u4f7f, Shutenshi)?, or less commonly and ambiguous with Principality, \"Angel of Authority\" (\u6b0a\u5929\u4f7f, Kentenshi or Gontenshi)?."
     },
     {
-      "name": "Lakshmi",
+      "name": "lakshmi",
+      "displayName": "Lakshmi",
       "evolvesTo": null,
       "primaryElement": "Ailment",
       "level": "23",
@@ -10085,7 +10247,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: range 5 ft., one target. \u000bHit: 2d4 + 5 physical damage."
+          "description": "Melee attack: range 5 ft., one target.\nHit: 2d4 + 5 physical damage."
         },
         {
           "name": "Lullaby (10 SP, 2 actions)",
@@ -10100,11 +10262,12 @@
           "description": "A gale of pure, arctic wind surrounds and freezes a foe solid. Make a ranged attack against a creature within range (-2 to hit, 30 feet). On a hit, they receive 3d8 + 4 ice damage. If each d6 in the attack roll is a 3 or higher, the target is also Frozen (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Lakshmi (Sanskrit: \u0932\u0915\u094d\u0937\u094d\u092e\u0940, Lak\u1e63m\u012b) is the Hindu goddess of beauty, luck, good fortune and love and is the wife of Vishnu, one of the Trimurti, and mother of Kama. Lakshmi stands atop a red lotus wearing a robe of lotuses with a lotus in her left hand. She embodies the ideal woman and is said to have charmed many gods with her dance. She is also one of the Tridevi, which consists of Lakshmi, Parvati (Shiva's wife) and Sarasvati (Brahma's wife).\n She is known in Japan as Kichijouten (\u5409\u7965\u5929*)? as an extra deity in the Seven Lucky Gods who sometimes replaces Jurojin. She was one of the things that rose from the oceans after the Churning of the Sea of Milk. She is also known as a goddess of farming and is called Kisshoten in Buddhism.\n"
+      "background": "Lakshmi (Sanskrit: \u0932\u0915\u094d\u0937\u094d\u092e\u0940, Lak\u1e63m\u012b) is the Hindu goddess of beauty, luck, good fortune and love and is the wife of Vishnu, one of the Trimurti, and mother of Kama. Lakshmi stands atop a red lotus wearing a robe of lotuses with a lotus in her left hand. She embodies the ideal woman and is said to have charmed many gods with her dance. She is also one of the Tridevi, which consists of Lakshmi, Parvati (Shiva's wife) and Sarasvati (Brahma's wife).\n\nShe is known in Japan as Kichijouten (\u5409\u7965\u5929*)? as an extra deity in the Seven Lucky Gods who sometimes replaces Jurojin. She was one of the things that rose from the oceans after the Churning of the Sea of Milk. She is also known as a goddess of farming and is called Kisshoten in Buddhism."
     },
     {
-      "name": "Loa",
-      "evolvesTo": "Satan",
+      "name": "loa",
+      "displayName": "Loa",
+      "evolvesTo": "satan",
       "primaryElement": "Curse",
       "level": "23",
       "arcana": "Hermit",
@@ -10153,7 +10316,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 2d6 + 4 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 2d6 + 4 physical damage."
         },
         {
           "name": "Mudoon (12 SP, 1 action)",
@@ -10165,14 +10328,15 @@
         },
         {
           "name": "Life Drain (5 SP, 1 action)",
-          "description": "You reach out, savoring life force from a foe. Make a ranged attack against a creature within range \u000b(-2 to hit, 30 feet). On a hit, the creature receives almighty damage, and you regain hit points equal to 9."
+          "description": "You reach out, savoring life force from a foe. Make a ranged attack against a creature within range\n(-2 to hit, 30 feet). On a hit, the creature receives almighty damage, and you regain hit points equal to 9."
         }
       ],
       "background": "Loa, also known as Lwa or Loi, is an intermediary spirit in Haitian mythology that stands between god and humans that expects to be properly served, not just communicated with. They are each distinct beings with their own personal likes and dislikes, distinct sacred rhythms, songs, dances, ritual symbols, and special modes of service. Contrary to popular belief, the loa are not deities in and of themselves; they are intermediaries for, and dependent on, a distant Bondye."
     },
     {
-      "name": "Vasuki",
-      "evolvesTo": "Vishnu",
+      "name": "vasuki",
+      "displayName": "Vasuki",
+      "evolvesTo": "vishnu",
       "primaryElement": "Ailment",
       "level": "23",
       "arcana": "Star",
@@ -10208,17 +10372,17 @@
       "traits": [
         {
           "name": "Foul Stench",
-          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         },
         {
           "name": "Down Shot",
-          "description": "A combination of skill and flamboyant carelessness lets you perform a special maneuver of covering fire. You gain the following benefits:\n \u2022 Whenever you roll 3d6 to make a Gun attack, if each d6 is the same result, the attack is a Critical hit.\n \u2022 As 1 action, you unleash a barrage of covering fire at a target within range of your firearm. This deals no damage, however the target is Downed. Once you use this ability, you cannot do so again until you fully recover in Reality. "
+          "description": "A combination of skill and flamboyant carelessness lets you perform a special maneuver of covering fire. You gain the following benefits:\n\u2022 Whenever you roll 3d6 to make a Gun attack, if each d6 is the same result, the attack is a Critical hit.\n\u2022 As 1 action, you unleash a barrage of covering fire at a target within range of your firearm. This deals no damage, however the target is Downed. Once you use this ability, you cannot do so again until you fully recover in Reality. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 2d6 + 3 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 2d6 + 3 physical damage."
         },
         {
           "name": "Brain Jack (10 SP, 2 actions)",
@@ -10226,18 +10390,19 @@
         },
         {
           "name": "Hamaon (12 SP, 1 action)",
-          "description": "Divine will and an excess of banishing rights and rituals consecrate the creature\u2019s space, purging it of evil and existence. Choose a creature within range and make a ranged attack against them \u000b(-2 to hit, 90 feet). On a hit, if the result of each d6 is 3 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Bless. This Skill provokes a One More if the target is weak to Bless."
+          "description": "Divine will and an excess of banishing rights and rituals consecrate the creature\u2019s space, purging it of evil and existence. Choose a creature within range and make a ranged attack against them\n(-2 to hit, 90 feet). On a hit, if the result of each d6 is 3 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Bless. This Skill provokes a One More if the target is weak to Bless."
         },
         {
           "name": "Triple Down (9 HP, 2 actions)",
-          "description": "A trifecta of cunning blows knock a foe asunder. Make three melee attacks against each creature within a 10-foot sphere centered at a point within range (-2 to hit, 10 feet). For each hit, the creature receives \u000b2d10 + 3 gun damage."
+          "description": "A trifecta of cunning blows knock a foe asunder. Make three melee attacks against each creature within a 10-foot sphere centered at a point within range (-2 to hit, 10 feet). For each hit, the creature receives\n2d10 + 3 gun damage."
         }
       ],
-      "background": "In the legend of the churning of the milk ocean, V\u0101suki allowed the Devas and Asuras to bind him to Mount Mandar to use him to churn the Amrita, the nectar of immortality. This happens after the devas and the asuras agree to join forces in order to gain the Amrita. It is also said that Indra tricked the asuras into holding V\u0101suki by its heads, so that they could inhale its hot breath. However, as the milk ocean was churned up, a poison seeped out which threatened the world. So Shiva swallowed the venom as an act of self-sacrifice to prevent premature destruction of the world, thus earning him the title of Nilakantha (\"blue throat\"). He has a sister called Manasa, who is a goddess of snakes and poison.\n"
+      "background": "In the legend of the churning of the milk ocean, V\u0101suki allowed the Devas and Asuras to bind him to Mount Mandar to use him to churn the Amrita, the nectar of immortality. This happens after the devas and the asuras agree to join forces in order to gain the Amrita. It is also said that Indra tricked the asuras into holding V\u0101suki by its heads, so that they could inhale its hot breath. However, as the milk ocean was churned up, a poison seeped out which threatened the world. So Shiva swallowed the venom as an act of self-sacrifice to prevent premature destruction of the world, thus earning him the title of Nilakantha (\"blue throat\"). He has a sister called Manasa, who is a goddess of snakes and poison."
     },
     {
-      "name": "Dionysus",
-      "evolvesTo": "Mada",
+      "name": "dionysus",
+      "displayName": "Dionysus",
+      "evolvesTo": "mada",
       "primaryElement": "Support",
       "level": "24",
       "arcana": "Councillor",
@@ -10273,7 +10438,7 @@
       "traits": [
         {
           "name": "Foul Stench",
-          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "A noxious, plague-like force infests foes. You gain the following benefits:\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         },
         {
           "name": "Mastery of Magic",
@@ -10283,11 +10448,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: range 5 ft., one target. \u000bHit: 2d4 + 4 physical damage."
+          "description": "Melee attack: range 5 ft., one target.\nHit: 2d4 + 4 physical damage."
         },
         {
           "name": "Thermopylae (24 SP, 2 actions)",
-          "description": "The intense heat of battle allows you to turn the tide. Choose up to six creatures within range \u000b(90 feet). Those creatures gain the effects of Tarukaja, Rakukaja, and Sukukaja. This Skill may only affect creatures with only half of their hit points remaining or less."
+          "description": "The intense heat of battle allows you to turn the tide. Choose up to six creatures within range\n(90 feet). Those creatures gain the effects of Tarukaja, Rakukaja, and Sukukaja. This Skill may only affect creatures with only half of their hit points remaining or less."
         },
         {
           "name": "Debilitate (18 SP, 1 action)",
@@ -10295,14 +10460,15 @@
         },
         {
           "name": "Brain Jack (10 SP, 2 actions)",
-          "description": "You\u2019re not asking anymore. You use magic to directly weave into the hearts of foes, seizing control of the field. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range \u000b(-2 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Brainwash (see \u201cConditions\u201d)."
+          "description": "You\u2019re not asking anymore. You use magic to directly weave into the hearts of foes, seizing control of the field. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range\n(-2 to hit, 20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Brainwash (see \u201cConditions\u201d)."
         }
       ],
       "background": "Dionysus is the ancient Greek god of wine, wine cups, wineskins, grapes and fertility. He inspires ritual madness, joyful worship, ecstasy, carnivals and celebration. He is sometimes included as one of the twelve Olympians. He was also known as Bacchus, the name adopted and used by the Romans and the frenzy he induced, bakkheia. In addition to wine-making, he is the patron deity of agriculture and the theater. Hailed as an Asiatic foreigner, he was thought to have had strong ties to the East and to Ethiopia in the South. He was also known as the Liberator, freeing one from one's normal self, by madness, ecstasy or wine. The divine mission of Dionysus was to mingle the music of the aulos and to bring an end to care and worry. Scholars have discussed Dionysus' relationship to the \"cult of the souls\" and his ability to preside over communication between the living and the dead."
     },
     {
-      "name": "Macabre",
-      "evolvesTo": "Alice",
+      "name": "macabre",
+      "displayName": "Macabre",
+      "evolvesTo": "alice",
       "primaryElement": "Physical",
       "level": "24",
       "arcana": "Hanged Man",
@@ -10339,17 +10505,17 @@
       "traits": [
         {
           "name": "Speed Master",
-          "description": "You have a unique sense for agile tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Sukukaja Skill at no cost or action."
+          "description": "You have a unique sense for agile tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Sukukaja Skill at no cost or action."
         },
         {
           "name": "Hollow Jester",
-          "description": "You seek out the weak-willed and the ailing pack. You gain the following benefits:\n \u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n \u2022 You may add half your character level (min 1) to the damage roll of any attack against a target afflicted with a Condition. You may add this bonus multiple times, once for each Condition the target is inflicted with. "
+          "description": "You seek out the weak-willed and the ailing pack. You gain the following benefits:\n\u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n\u2022 You may add half your character level (min 1) to the damage roll of any attack against a target afflicted with a Condition. You may add this bonus multiple times, once for each Condition the target is inflicted with. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 4 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 4 physical damage."
         },
         {
           "name": "Death Scythe (13 HP, 1 action)",
@@ -10367,7 +10533,8 @@
       "background": "A Macabre is a grim work of art with a ghastly atmosphere. Macabre works of art or fiction tend to emphasize the details and symbols of death. Danse Macabre or the \"Dance of Death\" works of art tend to depict the dead or Death itself summoning representatives from all walks of life to dance along to the grave. They were created to remind people of the fragility of their lives and how vain the glories of earthly life are. It is believed to originate from illustrated sermon texts."
     },
     {
-      "name": "Mara",
+      "name": "mara",
+      "displayName": "Mara",
       "evolvesTo": null,
       "primaryElement": "Psychic",
       "level": "24",
@@ -10412,13 +10579,13 @@
         },
         {
           "name": "Firm Stance",
-          "description": "Resilience and durability allow you to stand firm against all threats. You gain the following benefits:\n \u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n \u2022 When you are subjected to an attack, you may choose to use this ability. If you do, you cannot evade the attack, and you receive half as much damage from it. "
+          "description": "Resilience and durability allow you to stand firm against all threats. You gain the following benefits:\n\u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n\u2022 When you are subjected to an attack, you may choose to use this ability. If you do, you cannot evade the attack, and you receive half as much damage from it. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 2d8 + 5 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 2d8 + 5 physical damage."
         },
         {
           "name": "Psycho Force (24 SP, 1 action)",
@@ -10433,11 +10600,12 @@
           "description": "You begin amassing your strength and stamina, coalescing into an ultimate strike. The next damage roll you make for an attack that deals Physical or Gun damage within the next 10 minutes is doubled."
         }
       ],
-      "background": "In Buddhist\u2019s mythology, Mara is known as the Evil One. He is the tempter that causes people to regard the mundane and negative as attractive. Mara personifies unwholesome impulses, unskillfulness, and the death of the spiritual life.\n This demon lord sits atop the Sixth Heaven of the Desire Realm that includes the mortal world. Mara deceives those who travel through Samsara by using promises of happiness in the Desire Realms. The faithful see this as the ultimate obstacle to any who desire to achieve enlightenment into nirvana and sunyata.\n"
+      "background": "In Buddhist\u2019s mythology, Mara is known as the Evil One. He is the tempter that causes people to regard the mundane and negative as attractive. Mara personifies unwholesome impulses, unskillfulness, and the death of the spiritual life.\n\nThis demon lord sits atop the Sixth Heaven of the Desire Realm that includes the mortal world. Mara deceives those who travel through Samsara by using promises of happiness in the Desire Realms. The faithful see this as the ultimate obstacle to any who desire to achieve enlightenment into nirvana and sunyata."
     },
     {
-      "name": "Throne",
-      "evolvesTo": "Uriel",
+      "name": "throne",
+      "displayName": "Throne",
+      "evolvesTo": "uriel",
       "primaryElement": "Fire",
       "level": "24",
       "arcana": "Justice",
@@ -10485,11 +10653,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 4 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 4 physical damage."
         },
         {
           "name": "Inferno (24 SP, 1 action)",
-          "description": "A beam of disintegrating thermal blaze vaporizes those in your path. Make a ranged attack against a creature within range (-1 to hit, 60 feet). On a hit, they receive \u000b8d8 + 5 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
+          "description": "A beam of disintegrating thermal blaze vaporizes those in your path. Make a ranged attack against a creature within range (-1 to hit, 60 feet). On a hit, they receive\n8d8 + 5 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
         },
         {
           "name": "Hamaon (12 SP, 1 action)",
@@ -10500,10 +10668,11 @@
           "description": "You invoke holy will, and a cascading pillar of light and holy magic erupts from the foe\u2019s space. Make a ranged attack against a creature within range (-1 to hit, 60 feet). On a hit, they receive 4d8 + 5 bless damage."
         }
       ],
-      "background": "The Thrones, also known as the Elders, are the third of the First Sphere of angels in Christian angelology. They are known as the angels of knowledge, and have also been compared with Erelim, Galgalim and Ophanim.\n They are living symbols of God's justice and authority. They come the closest of all angels to spiritual perfection and emanate the light of God with mirror-like goodness. They, despite their greatness, are intensely humble, an attribute that allows them to dispense justice with perfect objectivity and without fear of pride or ambition.\n"
+      "background": "The Thrones, also known as the Elders, are the third of the First Sphere of angels in Christian angelology. They are known as the angels of knowledge, and have also been compared with Erelim, Galgalim and Ophanim.\n\nThey are living symbols of God's justice and authority. They come the closest of all angels to spiritual perfection and emanate the light of God with mirror-like goodness. They, despite their greatness, are intensely humble, an attribute that allows them to dispense justice with perfect objectivity and without fear of pride or ambition."
     },
     {
-      "name": "Abaddon",
+      "name": "abaddon",
+      "displayName": "Abaddon",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "25",
@@ -10545,13 +10714,13 @@
         },
         {
           "name": "Survival Trick",
-          "description": "With deceit and trickery, as well as resilience, you are able to avoid disaster. You gain the following benefits:\n \u2022 When you would be reduced to 0 hit points by a Hama or Mudo type Skill, or Door of Hades, you are reduced to 1 hit points instead.\n \u2022 When you would be reduced to 0 hit points by a hostile attack that is not a Hama or Mudo type Skill, or Door of Hades , you are reduced to 1 hit point instead. Once this ability is used, you cannot use it again until you fully recover in Reality. "
+          "description": "With deceit and trickery, as well as resilience, you are able to avoid disaster. You gain the following benefits:\n\u2022 When you would be reduced to 0 hit points by a Hama or Mudo type Skill, or Door of Hades, you are reduced to 1 hit points instead.\n\u2022 When you would be reduced to 0 hit points by a hostile attack that is not a Hama or Mudo type Skill, or Door of Hades , you are reduced to 1 hit point instead. Once this ability is used, you cannot use it again until you fully recover in Reality. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 2d8 + 5 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 2d8 + 5 physical damage."
         },
         {
           "name": "Gigantomachia (16 HP, 2 actions)",
@@ -10559,17 +10728,18 @@
         },
         {
           "name": "Megaton Raid (8 HP, 1 action)",
-          "description": "Absolute force of impact crushes a foe at your feet. Make a melee attack against a creature within range \u000b(-1 to hit, 5 feet). On a hit, the creature receives 4d8 + 5 physical damage."
+          "description": "Absolute force of impact crushes a foe at your feet. Make a melee attack against a creature within range\n(-1 to hit, 5 feet). On a hit, the creature receives 4d8 + 5 physical damage."
         },
         {
           "name": "Power Charge (15 SP, 1 action)",
           "description": "You begin amassing your strength and stamina, coalescing into an ultimate strike. The next damage roll you make for an attack that deals Physical or Gun damage within the next 10 minutes is doubled."
         }
       ],
-      "background": "Abaddon is a demon or angel that personified the abyss, becoming known as the \"Angel of the Abyss.\" He is often depicted as a large, human-sized locust and leads a swarm of locusts and other insects that carry infectious diseases. In this respect, he is often associated with the swarms of locusts that sometimes destroy entire crop fields and in the The Greater Key of Solomon was said to be called upon by Moses to cause the great rains during the Ten Plagues of Egypt.\n While in many circles he is considered to be associated with Satan, even going as far as to claim that Abaddon is another name for Satan, some depictions make him a righteous figure, and was charged with casting Lucifer down into the abyss and sealing him within. Abaddon has also been identified as the \"angel\" of death and destruction, demon of the abyss, and chief of demons of the underworld hierarchy, where he is equated with Samael or Satan. In demonology, he is said to tempt people with sloth and discord."
+      "background": "Abaddon is a demon or angel that personified the abyss, becoming known as the \"Angel of the Abyss.\" He is often depicted as a large, human-sized locust and leads a swarm of locusts and other insects that carry infectious diseases. In this respect, he is often associated with the swarms of locusts that sometimes destroy entire crop fields and in the The Greater Key of Solomon was said to be called upon by Moses to cause the great rains during the Ten Plagues of Egypt.\n\nWhile in many circles he is considered to be associated with Satan, even going as far as to claim that Abaddon is another name for Satan, some depictions make him a righteous figure, and was charged with casting Lucifer down into the abyss and sealing him within. Abaddon has also been identified as the \"angel\" of death and destruction, demon of the abyss, and chief of demons of the underworld hierarchy, where he is equated with Samael or Satan. In demonology, he is said to tempt people with sloth and discord."
     },
     {
-      "name": "Asura",
+      "name": "asura",
+      "displayName": "Asura",
       "evolvesTo": null,
       "primaryElement": "Nuke",
       "level": "25",
@@ -10617,7 +10787,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Atomic Flare (12 SP, 1 action)",
@@ -10632,10 +10802,11 @@
           "description": "You coordinate the defense of your allies, covering flanks and shielding them from danger. Choose up to six creatures within range (90 feet). Those creatures gain the effects of Rakukaja."
         }
       ],
-      "background": "Asuras are entities that take on varying roles in the Asian religions. In the old Vedic religion, they were simply gods of moral/social phenomenon who regularly competed with the Devas, who were gods of natural phenomenon.\n In Hinduism, they are fanatical, demon-like entities associated with carnal and materialistic pleasures, and often thirsted for violence, opposed to the more peace-inclined Devas. There are many kings and rulers of the Asura, but one major Asura Lord is based on Vairocana, also known as Maha Vairocana or Dainichi Nyorai, the king of the asuras who, alongside Indra, searched for the secret of enlightenment.\n"
+      "background": "Asuras are entities that take on varying roles in the Asian religions. In the old Vedic religion, they were simply gods of moral/social phenomenon who regularly competed with the Devas, who were gods of natural phenomenon.\n\nIn Hinduism, they are fanatical, demon-like entities associated with carnal and materialistic pleasures, and often thirsted for violence, opposed to the more peace-inclined Devas. There are many kings and rulers of the Asura, but one major Asura Lord is based on Vairocana, also known as Maha Vairocana or Dainichi Nyorai, the king of the asuras who, alongside Indra, searched for the secret of enlightenment."
     },
     {
-      "name": "Chimera",
+      "name": "chimera",
+      "displayName": "Chimera",
       "evolvesTo": null,
       "primaryElement": "Fire",
       "level": "25",
@@ -10674,17 +10845,17 @@
       "traits": [
         {
           "name": "Ghost Nest",
-          "description": "Ethereal claws of your will aid in penetrating the defenses of others. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with a Condition, roll 1d4. On a 4, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "Ethereal claws of your will aid in penetrating the defenses of others. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with a Condition, roll 1d4. On a 4, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         },
         {
           "name": "Attack Master",
-          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action. "
+          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 2d8 + 5 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 2d8 + 5 physical damage."
         },
         {
           "name": "Agidyne (16 SP, 1 action)",
@@ -10702,8 +10873,9 @@
       "background": "Chimera is the monster offspring of Typhon and Echidna from Greek mythology, and is the sibling of Cerberus and Orthrus. This monster breathes fire and is made up of parts from different animals; the general ones being the body and head of a lion, with a goat's head sprouting in the middle, and a snake's head for a tail. Other accounts include the Chimera being a three-headed animal, with a dragon being the third head."
     },
     {
-      "name": "Cu Chulainn",
-      "evolvesTo": "Siegfried",
+      "name": "cu-chulainn",
+      "displayName": "Cu Chulainn",
+      "evolvesTo": "siegfried",
       "primaryElement": "Gun",
       "level": "25",
       "arcana": "Faith",
@@ -10743,7 +10915,7 @@
       "traits": [
         {
           "name": "Apt Pupil",
-          "description": "Your skill and cunning allows you to avoid the worst of impacts. You gain the following benefits:\n \u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n \u2022 You score a critical hit for attacks where all d6s in the attack roll are a 2 or less."
+          "description": "Your skill and cunning allows you to avoid the worst of impacts. You gain the following benefits:\n\u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n\u2022 You score a critical hit for attacks where all d6s in the attack roll are a 2 or less."
         },
         {
           "name": "Counter",
@@ -10753,7 +10925,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "One-Shot Kill (9 HP, 1 action)",
@@ -10771,7 +10943,8 @@
       "background": "Cu Chulainn is an Irish mythical hero who appears in the stories of the Ulster Cycle, as well as in Scottish and Manx folklore. The son of the god Lugh and Deichtine (sister to the current king of Ulster), he was originally named Setanta, but gained his better-known name as a child after he killed Culann's fierce guard-dog in self-defense, and offered to take its place until a replacement could be reared. Cu Chulainn trained in war under the goddess Scathach, who lives in the Land of Shadows, and earned the magic spear Gae Bolg. At the age of seventeen, he defended Ulster single handedly against the armies of Queen Mab of Connacht in the epic Tain Bo Cuailnge. It was prophesied that his great deeds would give him everlasting fame, but that his life would be short; one reason he is compared to the Greek hero Achilles. He is known for his terrifying battle frenzy, in which he becomes an unrecognizable monster who knows neither friend nor foe. He fights from his chariot, driven by his loyal charioteer Laeg, and drawn by his horses, Liath Macha and Dub Sainglend."
     },
     {
-      "name": "Kohryu",
+      "name": "kohryu",
+      "displayName": "Kohryu",
       "evolvesTo": null,
       "primaryElement": "Psychic",
       "level": "25",
@@ -10820,7 +10993,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 3 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 3 physical damage."
         },
         {
           "name": "Psycho Force (24 SP, 1 action)",
@@ -10835,11 +11008,12 @@
           "description": "You gather and focus your mind's eye, delivering an absolute force of will. The next damage roll you make for an attack that deals Fire, Ice, Electric, Wind, Psychic, Nuke, Bless, Curse, or Almighty damage within the next 10 minutes is doubled."
         }
       ],
-      "background": "The Huang Long, literally meaning Yellow Dragon (\u9ec3\u9f8d), is the Chinese gold dragon that reigns over the Si Xiang, celestial creatures in Chinese constellation (Baihu, Xuanwu, Qinglong and Zhuque) and is located in the center of the four beasts. It is the embodiment of the element of Earth in Chinese five elements (Wu Xing) along with the Chinese quintessence, as well as the changing of the seasons. It is also known as Kohryu in Japan and Hwang-Ryong in Korea.\n Huang Long is sometimes regarded to be the same as Qilin from the Si Ling. The Yellow Dragon does not appear in Japanese mythology: the fifth element in the Japanese elemental system is the void, so there cannot be an animal representing it. However, some consider the \u014cry\u016b as the Japanese counterpart of the Yellow Dragon since they share some similarities."
+      "background": "The Huang Long, literally meaning Yellow Dragon (\u9ec3\u9f8d), is the Chinese gold dragon that reigns over the Si Xiang, celestial creatures in Chinese constellation (Baihu, Xuanwu, Qinglong and Zhuque) and is located in the center of the four beasts. It is the embodiment of the element of Earth in Chinese five elements (Wu Xing) along with the Chinese quintessence, as well as the changing of the seasons. It is also known as Kohryu in Japan and Hwang-Ryong in Korea.\n\nHuang Long is sometimes regarded to be the same as Qilin from the Si Ling. The Yellow Dragon does not appear in Japanese mythology: the fifth element in the Japanese elemental system is the void, so there cannot be an animal representing it. However, some consider the \u014cry\u016b as the Japanese counterpart of the Yellow Dragon since they share some similarities."
     },
     {
-      "name": "Nebiros",
-      "evolvesTo": "Beelzebub",
+      "name": "nebiros",
+      "displayName": "Nebiros",
+      "evolvesTo": "beelzebub",
       "primaryElement": "Ailment",
       "level": "25",
       "arcana": "Devil",
@@ -10880,13 +11054,13 @@
         },
         {
           "name": "Ghost Nest",
-          "description": "Ethereal claws of your will aid in penetrating the defenses of others. You gain the following benefits:\n \u2022 When you attempt to inflict a Downed creature with a Condition, roll 1d4. On a 4, the Condition is inflicted.\n \u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
+          "description": "Ethereal claws of your will aid in penetrating the defenses of others. You gain the following benefits:\n\u2022 When you attempt to inflict a Downed creature with a Condition, roll 1d4. On a 4, the Condition is inflicted.\n\u2022 When you make an attack with an Ailment type Skill, the attack is made with advantage."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 2d4 + 4 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 2d4 + 4 physical damage."
         },
         {
           "name": "Marin Karin (5 SP, 1 action)",
@@ -10904,8 +11078,9 @@
       "background": "The Grand Grimoire regards Nebiros as the field marshal and inspector general of the armies of Hell along with being one of the six great officers. He can be conjured to inflict woes upon anyone, discover the Hand of Glory, teach the mystic and occult qualities of all animals, plants and minerals and supply necromantic advice. One of the three Goetic nobles under his direct authority (the other two being Glasya-Labolas and Ayperos) is Naberius, the 24th demonic spirit of the Ars Goetia, suggesting that the Grand Grimoire Author understood the two spellings to signify distinct demons. Naberius is sometimes associated with the three headed Greek monster Cerberus."
     },
     {
-      "name": "Sandalphon",
-      "evolvesTo": "Metatron",
+      "name": "sandalphon",
+      "displayName": "Sandalphon",
+      "evolvesTo": "metatron",
       "primaryElement": "Bless",
       "level": "25",
       "arcana": "Moon",
@@ -10943,7 +11118,7 @@
       "traits": [
         {
           "name": "Omen",
-          "description": "You are a living embodiment of purgation. You gain the following benefits:\n \u2022 You have advantage on attacks made for Hama, Hamaon, Samsara, Mudo, Mudoon,  Die for Me!, and Door of Hades.\n \u2022 Whenever you make an attack roll for Hama, Hamaon, Samsara, Mudo, Mudoon,  Die for Me!, or Door of Hades, you may reroll any of the dice once. You must use the new result"
+          "description": "You are a living embodiment of purgation. You gain the following benefits:\n\u2022 You have advantage on attacks made for Hama, Hamaon, Samsara, Mudo, Mudoon,  Die for Me!, and Door of Hades.\n\u2022 Whenever you make an attack roll for Hama, Hamaon, Samsara, Mudo, Mudoon,  Die for Me!, or Door of Hades, you may reroll any of the dice once. You must use the new result"
         },
         {
           "name": "Fortify Spirit",
@@ -10953,25 +11128,26 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 3 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 3 physical damage."
         },
         {
           "name": "Hamaon (12 SP, 1 action)",
-          "description": "Divine will and an excess of banishing rights and rituals consecrate the creature\u2019s space, purging it of evil and existence. Choose a creature within range and make a ranged attack against them \u000b(-1 to hit, 90 feet). On a hit, if the result of each d6 is 3 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Bless. This Skill provokes a One More if the target is weak to Bless."
+          "description": "Divine will and an excess of banishing rights and rituals consecrate the creature\u2019s space, purging it of evil and existence. Choose a creature within range and make a ranged attack against them\n(-1 to hit, 90 feet). On a hit, if the result of each d6 is 3 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Bless. This Skill provokes a One More if the target is weak to Bless."
         },
         {
           "name": "Megidolaon (36 SP, 2 actions)",
-          "description": "A flash of light. A singularity instantly expands, as a reality-busting sphere of destructive energy emerges from the ground, blinding and erasing all. Make a ranged attack against each creature within a 20-foot radius sphere centered at a point within range \u000b(-1 to hit, 20 feet). On a hit, a creature receives 4d8 + 5 almighty damage."
+          "description": "A flash of light. A singularity instantly expands, as a reality-busting sphere of destructive energy emerges from the ground, blinding and erasing all. Make a ranged attack against each creature within a 20-foot radius sphere centered at a point within range\n(-1 to hit, 20 feet). On a hit, a creature receives 4d8 + 5 almighty damage."
         },
         {
           "name": "Amrita Shower (12 SP, 2 actions)",
           "description": "You remedy the impurities of all your comrades, cleansing the field of malady. Choose up to six creatures within range (90 feet). Each of those creatures recover from all Conditions."
         }
       ],
-      "background": "Sandalphon is an archangel or seraphim that is prominently featured in Jewish mysticism, such as the Kabbalah where he resides in the Sephirot of Malkuth alongside his \"twin brother\" Metatron. Sandalphon is described as the \"dark angel\" as opposed to his twin brother Metatron who is regarded as the bright angel.\n Sandalphon is regarded as the master of heavenly songs and it is said that a human would take 500 years to walk the length of his body alone clearly showing his celestial size.\n"
+      "background": "Sandalphon is an archangel or seraphim that is prominently featured in Jewish mysticism, such as the Kabbalah where he resides in the Sephirot of Malkuth alongside his \"twin brother\" Metatron. Sandalphon is described as the \"dark angel\" as opposed to his twin brother Metatron who is regarded as the bright angel.\n\nSandalphon is regarded as the master of heavenly songs and it is said that a human would take 500 years to walk the length of his body alone clearly showing his celestial size."
     },
     {
-      "name": "Gabriel",
+      "name": "gabriel",
+      "displayName": "Gabriel",
       "evolvesTo": null,
       "primaryElement": "Bless",
       "level": "26",
@@ -11017,25 +11193,26 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 3 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 3 physical damage."
         },
         {
           "name": "Divine Judgement (24 SP, 2 actions)",
-          "description": "You call upon the decree of the heavens, which manifest as a gavel that descends and casts judgement upon a foe. Make a ranged attack against a creature within range \u000b(-1 to hit, 30 feet). On a hit, they receive bless damage equal to half of their remaining hit points. This Skill is unaffected by Concentrate."
+          "description": "You call upon the decree of the heavens, which manifest as a gavel that descends and casts judgement upon a foe. Make a ranged attack against a creature within range\n(-1 to hit, 30 feet). On a hit, they receive bless damage equal to half of their remaining hit points. This Skill is unaffected by Concentrate."
         },
         {
           "name": "Bufudyne (16 SP, 1 action)",
-          "description": "A gale of pure, arctic wind surrounds and freezes a foe solid. Make a ranged attack against a creature within range \u000b(-1 to hit, 30 feet). On a hit, they receive 6d8 + 5 ice damage. If each d6 in the attack roll is a 3 or higher, the target is also Frozen (see \u201cConditions\u201d)."
+          "description": "A gale of pure, arctic wind surrounds and freezes a foe solid. Make a ranged attack against a creature within range\n(-1 to hit, 30 feet). On a hit, they receive 6d8 + 5 ice damage. If each d6 in the attack roll is a 3 or higher, the target is also Frozen (see \u201cConditions\u201d)."
         },
         {
           "name": "Salvation (60 SP, 2 actions)",
-          "description": "Divine will invigorates you and your allies. Choose up to six creatures within range (90 feet). Those creatures regain \u000b8d8 + 11 hit points. Each of those creatures recover from all Conditions."
+          "description": "Divine will invigorates you and your allies. Choose up to six creatures within range (90 feet). Those creatures regain\n8d8 + 11 hit points. Each of those creatures recover from all Conditions."
         }
       ],
       "background": "Gabriel is a high-ranking messenger angel and true archangel in the Abrahamic trio of religions (which encompasses Christianity, Judaism and Islam. Their name means \"God is my strength\" and is known to be the left hand of God and the embodiment of the holy spirit, in contrast to Michael who is the right hand of God. To Christians, Gabriel's primary task is that of a messenger who told Elizabeth that she would bear John the Baptist and Mary that she would bear Jesus, meaning they are remembered each Christmas/Advent as the messenger of the Annunciation or Immaculate Conception (it was also Gabriel who asked Mary to name her son Jesus, meaning \"savior.\") They are also mentioned as announcing the prophecy of seventy weeks to Daniel and is also recognized as St. Gabriel, the patron saint of communications workers. For Muslims, Gabriel is especially noted for revealing the Qur'an to Muhammad and for being the messenger that tells prophets of their obligations. In Islam, Gabriel is the highest-ranking angel, while Raphael is the second. They are also called the holy spirit in Islam."
     },
     {
-      "name": "Raphael",
+      "name": "raphael",
+      "displayName": "Raphael",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "26",
@@ -11076,17 +11253,17 @@
         },
         {
           "name": "Apt Pupil",
-          "description": "Your skill and cunning allows you to avoid the worst of impacts. You gain the following benefits:\n \u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n \u2022 You score a critical hit for attacks where all d6s in the attack roll are a 2 or less."
+          "description": "Your skill and cunning allows you to avoid the worst of impacts. You gain the following benefits:\n\u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n\u2022 You score a critical hit for attacks where all d6s in the attack roll are a 2 or less."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Sword Dance (15 HP, 1 action)",
-          "description": "Conjured blades coil, swirl and dance in a perfect harmony, before slamming and skewering the target into smithereens. Make a melee attack against a creature within range (-1 to hit, 20 feet). On a hit, a creature receives \u000b5d10 + 5 physical damage. This Skill scores a Critical hit if the result of each d6 in its attack roll is 5 or higher."
+          "description": "Conjured blades coil, swirl and dance in a perfect harmony, before slamming and skewering the target into smithereens. Make a melee attack against a creature within range (-1 to hit, 20 feet). On a hit, a creature receives\n5d10 + 5 physical damage. This Skill scores a Critical hit if the result of each d6 in its attack roll is 5 or higher."
         },
         {
           "name": "Dekaja (12 SP, 2 actions)",
@@ -11097,10 +11274,12 @@
           "description": "The aid of magic releases an ally\u2019s limiters, allowing them to fight at full potential. Choose a creature within range (90 feet). This creature gains the effects of Tarukaja, Rakukaja, and Sukukaja."
         }
       ],
-      "background": "Raphael, or Raphaela, is one of the four main seraphim or archangels of God within the hierarchy of angels from Christian and Islamic mythology, His name means \"It is God that heals.\" Not all branches of these religions consider the identification of Raphael to be canonical.\n He is said to be the guardian of the Tree of Life, opposite the Tree of Knowledge in the Garden of Eden. He also expounds to Adam the War in Heaven in which Lucifer and the Fallen angels fell, and the creation of the Earth. Raphael first appears disguised in human form as the travelling companion of Tobit's son Tobiah, calling himself \"Azarias the son of the great Ananias\".\n"
+      "background": "Raphael, or Raphaela, is one of the four main seraphim or archangels of God within the hierarchy of angels from Christian and Islamic mythology, His name means \"It is God that heals.\" Not all branches of these religions consider the identification of Raphael to be canonical.\n\nHe is said to be the guardian of the Tree of Life, opposite the Tree of Knowledge in the Garden of Eden. He also expounds to Adam the War in Heaven in which Lucifer and the Fallen angels fell, and the creation of the Earth. Raphael first appears disguised in human form as the travelling companion of Tobit's son Tobiah, calling himself \"Azarias the son of the great Ananias\"."
     },
     {
-      "name": "Scathach",
+      "name": "scathach",
+      "displayName": "Scathach",
+      "evolvesTo": null,
       "level": "26",
       "arcana": "Priestess",
       "alignment": "Lawful Good",
@@ -11135,7 +11314,7 @@
       "traits": [
         {
           "name": "Attack Master",
-          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action."
+          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action."
         },
         {
           "name": "Skillful Technique",
@@ -11145,11 +11324,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Bufudyne (16 SP, 1 action)",
-          "description": "A gale of pure, arctic wind surrounds and freezes a foe solid. Make a ranged attack against a creature within range \u000b(-1 to hit, 30 feet). On a hit, they receive 3d8 + 5 ice damage. If each d6 in the attack roll is a 3 or higher, the target is also Frozen (see \u201cConditions\u201d)."
+          "description": "A gale of pure, arctic wind surrounds and freezes a foe solid. Make a ranged attack against a creature within range\n(-1 to hit, 30 feet). On a hit, they receive 3d8 + 5 ice damage. If each d6 in the attack roll is a 3 or higher, the target is also Frozen (see \u201cConditions\u201d)."
         },
         {
           "name": "Makarakarn (20 SP, 1 action)",
@@ -11160,10 +11339,11 @@
           "description": "Blinding speed and surgical precision envelop an area with slashes. Make a melee attack against a creature within a 10-foot sphere, centered at a point within range (-1 to hit, 10 feet). On a hit, a creature receives 4d10 + 5 physical damage."
         }
       ],
-      "background": "Scathach (\"Shadowy\") also known as \"The Shadowy One,\" is a legendary figure in the Ulster Cycle of Irish mythology. She is a Scottish warrior woman and martial arts teacher who trains the legendary Ulster hero Cu Chulainn in the arts of combat. Texts describe her homeland as \"Alpi,\" which commentators associate with Alba, the Gaelic name of Scotland; she is especially associated with the Isle of Skye, where her residence D\u00fan Sc\u00e1ith (Fort of Shadows) stands.\n Scathach's instruction of Cu Chulainn appears in Tochmarc Emire (The Wooing of Emer), a foretale to the great epic \"T\u00e1in B\u00f3 C\u00faailnge.\" Cu Chulainn and Emer fall in love, but her father Forgall forbade the union until Cu Chulainn has completed his warrior training. Cu Chulainn and his friend Ferdiad travel to D\u00fan Sc\u00e1ith, where Scathach teaches them feats of arms, and gives Cu Chulainn his deadly spear, the G\u00e1e Bulg.\n"
+      "background": "Scathach (\"Shadowy\") also known as \"The Shadowy One,\" is a legendary figure in the Ulster Cycle of Irish mythology. She is a Scottish warrior woman and martial arts teacher who trains the legendary Ulster hero Cu Chulainn in the arts of combat. Texts describe her homeland as \"Alpi,\" which commentators associate with Alba, the Gaelic name of Scotland; she is especially associated with the Isle of Skye, where her residence D\u00fan Sc\u00e1ith (Fort of Shadows) stands.\n\nScathach's instruction of Cu Chulainn appears in Tochmarc Emire (The Wooing of Emer), a foretale to the great epic \"T\u00e1in B\u00f3 C\u00faailnge.\" Cu Chulainn and Emer fall in love, but her father Forgall forbade the union until Cu Chulainn has completed his warrior training. Cu Chulainn and his friend Ferdiad travel to D\u00fan Sc\u00e1ith, where Scathach teaches them feats of arms, and gives Cu Chulainn his deadly spear, the G\u00e1e Bulg."
     },
     {
-      "name": "Alilat",
+      "name": "alilat",
+      "displayName": "Alilat",
       "evolvesTo": null,
       "primaryElement": "Ice",
       "level": "27",
@@ -11215,7 +11395,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 3 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 3 physical damage."
         },
         {
           "name": "Ice Age (12 SP, 2 actions)",
@@ -11230,10 +11410,11 @@
           "description": "You gather and focus your mind's eye, delivering an absolute force of will. The next damage roll you make for an attack that deals Fire, Ice, Electric, Wind, Psychic, Nuke, Bless, Curse, or Almighty damage within the next 10 minutes is doubled."
         }
       ],
-      "background": "Al-Lat, also known as Allat, Alilat or Allatu, was a major goddess worshiped all across the Arabian Peninsula as well as in present day Syria in antiquity, especially popular among the Nabateans. Her precise sphere of influence is uncertain; various researchers propose solar, lunar or an otherwise astral character, but nothing can be said with absolute certainty. Her sacred animals were lions and gazelles.\n The Nabateans regarded Alilat as a mother goddess, but also conflated her with the Greek Athena and her Roman counterpart Minerva, despite Alilat seemingly lacking any warlike traits herself. She was either the mother or wife of the popular Nabatean god Dushara, considered to be the equivalent of either Zeus or Dionysus."
+      "background": "Al-Lat, also known as Allat, Alilat or Allatu, was a major goddess worshiped all across the Arabian Peninsula as well as in present day Syria in antiquity, especially popular among the Nabateans. Her precise sphere of influence is uncertain; various researchers propose solar, lunar or an otherwise astral character, but nothing can be said with absolute certainty. Her sacred animals were lions and gazelles.\n\nThe Nabateans regarded Alilat as a mother goddess, but also conflated her with the Greek Athena and her Roman counterpart Minerva, despite Alilat seemingly lacking any warlike traits herself. She was either the mother or wife of the popular Nabatean god Dushara, considered to be the equivalent of either Zeus or Dionysus."
     },
     {
-      "name": "Attis",
+      "name": "attis",
+      "displayName": "Attis",
       "evolvesTo": null,
       "primaryElement": "Fire",
       "level": "27",
@@ -11281,25 +11462,26 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 2d4 + 5 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 2d4 + 5 physical damage."
         },
         {
           "name": "Blazing Hell (24 SP, 2 actions)",
-          "description": "You unleash a massive swathe of magmatic force, disintegrating and melting all matter and unlucky enemies caught within the area with a high chance of Burn. Make a ranged attack against each creature within a 20-feet sphere centered at a point within range \u000b(-1 to hit, 20 feet). On a hit, they receive 4d8 + 5 fire damage. If each d6 in the attack roll is a 3 or higher, the target is also Burned (see \u201cConditions\u201d)."
+          "description": "You unleash a massive swathe of magmatic force, disintegrating and melting all matter and unlucky enemies caught within the area with a high chance of Burn. Make a ranged attack against each creature within a 20-feet sphere centered at a point within range\n(-1 to hit, 20 feet). On a hit, they receive 4d8 + 5 fire damage. If each d6 in the attack roll is a 3 or higher, the target is also Burned (see \u201cConditions\u201d)."
         },
         {
           "name": "Salvation (60 SP, 2 actions)",
-          "description": "Divine will invigorates you and your allies. Choose up to six creatures within range (90 feet). Those creatures regain \u000b8d8 + 11 hit points. Each of those creatures recover from all Conditions."
+          "description": "Divine will invigorates you and your allies. Choose up to six creatures within range (90 feet). Those creatures regain\n8d8 + 11 hit points. Each of those creatures recover from all Conditions."
         },
         {
           "name": "Thermopylae (24 SP, 2 actions)",
-          "description": "The intense heat of battle allows you to turn the tide. Choose up to six creatures within range \u000b(90 feet). Those creatures gain the effects of Tarukaja, Rakukaja, and Sukukaja. This Skill may only affect creatures with only half of their hit points remaining or less."
+          "description": "The intense heat of battle allows you to turn the tide. Choose up to six creatures within range\n(90 feet). Those creatures gain the effects of Tarukaja, Rakukaja, and Sukukaja. This Skill may only affect creatures with only half of their hit points remaining or less."
         }
       ],
-      "background": "Attis originated in the kingdom of Phrygia and eventually became a part of Greek lore. Attis was conceived when his mother Nana ate a fruit from a tree that grew on the site where Agdistis, Cybele's son from Zeus, had its male sexual organs castrated and buried.\n Attis grew up to be a handsome man who attracted Cybele's attention, but when he ran away rejecting her love, Cybele chased after him. Attis arrived at the site of a pine tree, castrated himself and died. The pine tree protected his spirit, while Zeus and Cybele worked to keep his body from rotting. In celebration of his rebirth, Attis' followers would do the same and castrate themselves.\n"
+      "background": "Attis originated in the kingdom of Phrygia and eventually became a part of Greek lore. Attis was conceived when his mother Nana ate a fruit from a tree that grew on the site where Agdistis, Cybele's son from Zeus, had its male sexual organs castrated and buried.\n\nAttis grew up to be a handsome man who attracted Cybele's attention, but when he ran away rejecting her love, Cybele chased after him. Attis arrived at the site of a pine tree, castrated himself and died. The pine tree protected his spirit, while Zeus and Cybele worked to keep his body from rotting. In celebration of his rebirth, Attis' followers would do the same and castrate themselves."
     },
     {
-      "name": "Baal",
+      "name": "baal",
+      "displayName": "Baal",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "27",
@@ -11346,7 +11528,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Ayamur (17 HP, 2 actions)",
@@ -11364,7 +11546,8 @@
       "background": "Baal is a western Semitic title that means Master or Lord. While it can actually refer to a large number of different deities, Baal in this case refers to Hadad, the Canaanite and Syrian god of rain, fertility, life, agriculture and thunder, particularly popular in Ugarit and Aleppo. He was worshipped in many ancient Middle Eastern communities, who considered him one of the most important gods in their respective local pantheons. He was at least in part derived from the Sumerian god Ishkur, but their character differed substantially; while Ishkur represented the destructive power of storms, the western Semitic Baal was the master of life-giving rains vital for farmers."
     },
     {
-      "name": "Belial",
+      "name": "belial",
+      "displayName": "Belial",
       "evolvesTo": null,
       "primaryElement": "Curse",
       "level": "27",
@@ -11409,11 +11592,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Demonic Decree (24 SP, 2 actions)",
-          "description": "By right of your wretched will, a scythe of malice manifests from the earth, only to slice and sunder the will of an unsuspecting foe. Make a ranged attack against a creature within range \u000b(-1 to hit, 30 feet). On a hit, they receive curse damage equal to half of their remaining hit points + 3d8. This Skill is unaffected by Concentrate."
+          "description": "By right of your wretched will, a scythe of malice manifests from the earth, only to slice and sunder the will of an unsuspecting foe. Make a ranged attack against a creature within range\n(-1 to hit, 30 feet). On a hit, they receive curse damage equal to half of their remaining hit points + 3d8. This Skill is unaffected by Concentrate."
         },
         {
           "name": "Mudoon (12 SP, 1 action)",
@@ -11424,10 +11607,11 @@
           "description": "You whisper terrible, forbidden knowledge that plunges a foe closer to madness. Make a ranged attack against a creature within range (-1 to hit, 60 feet). On a hit, if the result of each d6 is 2 or higher, the target is inflicted with Despair (see \u201cConditions\u201d)."
         }
       ],
-      "background": "Belial, also known as Berial, Baalial, Balial, Belhor, Beliall, Beliar, Beliel or Beliya'al, is the 68th demonic spirit in Ars Goetia and one of the four crowned princes of Hell ruling over the North. He is a mighty and powerful king that was created next after Lucifer and is of his order. He appears in the form of a beautiful angel sitting in a chariot of fire and speaks with a comely voice.\n His office is to distribute preferences of senatorships and to cause favor of friends or foes. He bestows excellent familiars and governs 80 legions of spirits. Whoever summons him must have offerings of gifts or sacrifices or he will not give true answers to their demands, but even then with those, he will not spend more than one hour on the truth unless constrained by divine power or his seal, to be worn as a lamin by the person who summons him.\n"
+      "background": "Belial, also known as Berial, Baalial, Balial, Belhor, Beliall, Beliar, Beliel or Beliya'al, is the 68th demonic spirit in Ars Goetia and one of the four crowned princes of Hell ruling over the North. He is a mighty and powerful king that was created next after Lucifer and is of his order. He appears in the form of a beautiful angel sitting in a chariot of fire and speaks with a comely voice.\n\nHis office is to distribute preferences of senatorships and to cause favor of friends or foes. He bestows excellent familiars and governs 80 legions of spirits. Whoever summons him must have offerings of gifts or sacrifices or he will not give true answers to their demands, but even then with those, he will not spend more than one hour on the truth unless constrained by divine power or his seal, to be worn as a lamin by the person who summons him."
     },
     {
-      "name": "Messiah",
+      "name": "messiah",
+      "displayName": "Messiah",
       "evolvesTo": null,
       "primaryElement": "Healing",
       "level": "27",
@@ -11480,25 +11664,26 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 4 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 4 physical damage."
         },
         {
           "name": "Oratorio (36 SP, 2 actions)",
-          "description": "The benevolence and good will of Messiah rejuvenates others from the abyss, allowing them to overcome any hurdle. Choose up to six creatures within range \u000b(90 feet). Those creatures regain 6d8 + 10 hit points. The effects of Tarunda, Rakunda, and Sukunda are removed from those creatures."
+          "description": "The benevolence and good will of Messiah rejuvenates others from the abyss, allowing them to overcome any hurdle. Choose up to six creatures within range\n(90 feet). Those creatures regain 6d8 + 10 hit points. The effects of Tarunda, Rakunda, and Sukunda are removed from those creatures."
         },
         {
           "name": "Megidolaon (36 SP, 2 actions)",
-          "description": "A flash of light. A singularity instantly expands, as a reality-busting sphere of destructive energy emerges from the ground, blinding and erasing all. Make a ranged attack against each creature within a 20-foot radius sphere centered at a point within range \u000b(-1 to hit, 20 feet). On a hit, a creature receives 7d8 + 5 almighty damage."
+          "description": "A flash of light. A singularity instantly expands, as a reality-busting sphere of destructive energy emerges from the ground, blinding and erasing all. Make a ranged attack against each creature within a 20-foot radius sphere centered at a point within range\n(-1 to hit, 20 feet). On a hit, a creature receives 7d8 + 5 almighty damage."
         },
         {
           "name": "God Hand (14 HP, 1 action)",
-          "description": "You unleash a large, concentrated wave of raw power and force. It shoots forward from your own, crushing those underneath it with obliterating impact. Make a melee attack against a creature within range (-1 to hit, 20 feet). On a hit, the creature receives \u000b5d8 + 3 physical damage. You may move to an unoccupied space within 5 feet of the target after attacking. This attack may not connect if movement to this space is prevented."
+          "description": "You unleash a large, concentrated wave of raw power and force. It shoots forward from your own, crushing those underneath it with obliterating impact. Make a melee attack against a creature within range (-1 to hit, 20 feet). On a hit, the creature receives\n5d8 + 3 physical damage. You may move to an unoccupied space within 5 feet of the target after attacking. This attack may not connect if movement to this space is prevented."
         }
       ],
-      "background": "The term messiah (in Hebrew) or Christ (in Greek) is prominent within the world's many religions, especially in the Abrahamic religions Judaism and Christianity. A messiah is regarded as a savior of mankind who would bring them salvation near the end of days, although opinions between who the term messiah refers to differs between religions.\n The most common opinion in the West is the Christian one, which holds that the messiah is Jesus Christ. Other messiah figures have appeared in both history and myth and people have placed their hopes in them for salvation, Buddha, Krishna and Maitreya being examples.\n"
+      "background": "The term messiah (in Hebrew) or Christ (in Greek) is prominent within the world's many religions, especially in the Abrahamic religions Judaism and Christianity. A messiah is regarded as a savior of mankind who would bring them salvation near the end of days, although opinions between who the term messiah refers to differs between religions.\n\nThe most common opinion in the West is the Christian one, which holds that the messiah is Jesus Christ. Other messiah figures have appeared in both history and myth and people have placed their hopes in them for salvation, Buddha, Krishna and Maitreya being examples."
     },
     {
-      "name": "Sraosha",
+      "name": "sraosha",
+      "displayName": "Sraosha",
       "evolvesTo": null,
       "primaryElement": "Bless",
       "level": "27",
@@ -11546,7 +11731,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 2d4 + 4 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 2d4 + 4 physical damage."
         },
         {
           "name": "Kougaon (16 SP, 1 action)",
@@ -11554,7 +11739,7 @@
         },
         {
           "name": "Hamaon (12 SP, 1 action)",
-          "description": "Divine will and an excess of banishing rights and rituals consecrate the creature\u2019s space, purging it of evil and existence. Choose a creature within range and make a ranged attack against them \u000b(-1 to hit, 90 feet). On a hit, if the result of each d6 is 3 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Bless. This Skill provokes a One More if the target is weak to Bless."
+          "description": "Divine will and an excess of banishing rights and rituals consecrate the creature\u2019s space, purging it of evil and existence. Choose a creature within range and make a ranged attack against them\n(-1 to hit, 90 feet). On a hit, if the result of each d6 is 3 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Bless. This Skill provokes a One More if the target is weak to Bless."
         },
         {
           "name": "Debilitate (18 SP, 1 action)",
@@ -11564,7 +11749,8 @@
       "background": "Sraosha is one of the most prominent Yazatas (\"worthy of worship\"; sometimes translated simply as \"angels\" though this view is not entirely correct) in the Zoroastrian faith. Unlike many other Zoroastrian figures, he has no counterpart in Vedic texts. His name corresponds to the concept of obedience. He propagates religious doctrine on earth, and serves as a medium between the faithful and Ahura Mazda (Ohrmazd). While he's already prominent in the Gathas, the oldest Zoroastrian sacred texts, in later sources, he was eventually elevated to a position almost equal to that of Ohrmazd himself, being tasked with protecting the material world.[1] In this role, he's a scourge of evil beings. His strength is described as unusual, and the weapon he uses to dispatch evildoers is a club. His archenemy and antithesis is Aeshma, also known for using a mace."
     },
     {
-      "name": "Uriel",
+      "name": "uriel",
+      "displayName": "Uriel",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "27",
@@ -11612,7 +11798,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Bloodbath (16 HP, 2 actions)",
@@ -11620,17 +11806,18 @@
         },
         {
           "name": "Megidolaon (36 SP, 2 actions)",
-          "description": "A flash of light. A singularity instantly expands, as a reality-busting sphere of destructive energy emerges from the ground, blinding and erasing all. Make a ranged attack against each creature within a 20-foot radius sphere centered at a point within range \u000b(-1 to hit, 20 feet). On a hit, a creature receives 4d8 + 5 almighty damage."
+          "description": "A flash of light. A singularity instantly expands, as a reality-busting sphere of destructive energy emerges from the ground, blinding and erasing all. Make a ranged attack against each creature within a 20-foot radius sphere centered at a point within range\n(-1 to hit, 20 feet). On a hit, a creature receives 4d8 + 5 almighty damage."
         },
         {
           "name": "Agidyne (16 SP, 1 action)",
           "description": "A pillar-shaped conflagration erupts, spiraling about and enveloping a foe. Make a ranged attack against a creature within range (-1 to hit, 30 feet). On a hit, they receive 7d8 + 5 fire damage. If each d6 in the attack roll is a 4 or higher, the target is also Burned (see \u201cConditions\u201d)."
         }
       ],
-      "background": "In Abrahamic religion, Uriel was a high ranking archangel or seraph who was listed as the fourth angel that represented the four cardinal points, the others being Michael, Gabriel and Raphael.\n People sometimes ask for Uriel\u2019s help to: seek God\u2019s will before making decisions, come up with fresh creative ideas, learn new information, solve problems, resolve conflicts, let go of destructive emotions such as anxiety and anger that can prevent them from discerning wisdom, and recognize dangerous situations so they can try to avoid them.\n Although he is never mentioned by name in any of the widely accepted holy scriptures, he came to be known as Uriel, which means \"Flame of God,\" for his depiction of holding a flaming sword. He is said to carry the stars in the sky, and on the final day of judgement, he will oversee the resurrection and retribution of human souls. According to the Apocrypha, Uriel was the guardian to the gates of the Garden of Eden.\n"
+      "background": "In Abrahamic religion, Uriel was a high ranking archangel or seraph who was listed as the fourth angel that represented the four cardinal points, the others being Michael, Gabriel and Raphael.\n\nPeople sometimes ask for Uriel\u2019s help to: seek God\u2019s will before making decisions, come up with fresh creative ideas, learn new information, solve problems, resolve conflicts, let go of destructive emotions such as anxiety and anger that can prevent them from discerning wisdom, and recognize dangerous situations so they can try to avoid them.\n\nAlthough he is never mentioned by name in any of the widely accepted holy scriptures, he came to be known as Uriel, which means \"Flame of God,\" for his depiction of holding a flaming sword. He is said to carry the stars in the sky, and on the final day of judgement, he will oversee the resurrection and retribution of human souls. According to the Apocrypha, Uriel was the guardian to the gates of the Garden of Eden."
     },
     {
-      "name": "Shiva",
+      "name": "shiva",
+      "displayName": "Shiva",
       "evolvesTo": null,
       "primaryElement": "Psychic",
       "level": "27",
@@ -11676,13 +11863,13 @@
         },
         {
           "name": "Attack Master",
-          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action "
+          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Psycho Blast (24 SP, 2 actions)",
@@ -11690,17 +11877,18 @@
         },
         {
           "name": "Ziodyne (16 SP, 1 action)",
-          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (-1 to hit, 30 feet). On a hit, they receive \u000b3d8 + 5 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)"
+          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (-1 to hit, 30 feet). On a hit, they receive\n3d8 + 5 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)"
         },
         {
           "name": "Riot Gun (12 HP, 2 actions)",
-          "description": "A shower of piercing shots rain from the heavens above, turning foes into ribbons. Make a ranged attack against each creature within a 20-feet sphere, centered at a point within range (-1 to hit, 60 feet). On a hit, the creature receives \u000b5d10 + 5 gun damage."
+          "description": "A shower of piercing shots rain from the heavens above, turning foes into ribbons. Make a ranged attack against each creature within a 20-feet sphere, centered at a point within range (-1 to hit, 60 feet). On a hit, the creature receives\n5d10 + 5 gun damage."
         }
       ],
       "background": "In the Hindu religion, Shiva the Destroyer is one of the three principal deities of the Trimurti (Hindu Male Triad) along with Brahma the Creator and Vishnu the Preserver. He originally evolved from the early Vedic god, Rudra, and is now the supreme deity within Shaivism, a branch of Hinduism that focuses on the worship of Shiva. While he is known as the destroyer, he is also considered to be a benevolent and beneficial force, as without destruction, new creation couldn't take place. He also acts against premature destruction, going far enough to withstand great suffering. He is depicted with up to four arms, a third eye, a blue throat, matted hair, carrying a trident and a drum, is often accompanied by a serpent and rides on the back of the sacred bull Nandi."
     },
     {
-      "name": "Vohu Manah",
+      "name": "vohu-manah",
+      "displayName": "Vohu Manah",
       "evolvesTo": null,
       "primaryElement": "Bless",
       "level": "27",
@@ -11750,25 +11938,26 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 2d4 + 4 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 2d4 + 4 physical damage."
         },
         {
           "name": "Divine Judgement (24 SP, 2 actions)",
-          "description": "You call upon the decree of the heavens, which manifest as a gavel that descends and casts judgement upon a foe. Make a ranged attack against a creature within range \u000b(-1 to hit, 30 feet). On a hit, they receive bless damage equal to half of their remaining hit points + 3d8. This Skill is unaffected by Concentrate."
+          "description": "You call upon the decree of the heavens, which manifest as a gavel that descends and casts judgement upon a foe. Make a ranged attack against a creature within range\n(-1 to hit, 30 feet). On a hit, they receive bless damage equal to half of their remaining hit points + 3d8. This Skill is unaffected by Concentrate."
         },
         {
           "name": "Thermopylae (24 SP, 2 actions)",
-          "description": "The intense heat of battle allows you to turn the tide. Choose up to six creatures within range \u000b(90 feet). Those creatures gain the effects of Tarukaja, Rakukaja, and Sukukaja. This Skill may only affect creatures with only half of their hit points remaining or less."
+          "description": "The intense heat of battle allows you to turn the tide. Choose up to six creatures within range\n(90 feet). Those creatures gain the effects of Tarukaja, Rakukaja, and Sukukaja. This Skill may only affect creatures with only half of their hit points remaining or less."
         },
         {
           "name": "Salvation (60 SP, 2 actions)",
-          "description": "Divine will invigorates you and your allies. Choose up to six creatures within range (90 feet). Those creatures regain \u000b8d8 + 11 hit points. Each of those creatures recover from all Conditions."
+          "description": "Divine will invigorates you and your allies. Choose up to six creatures within range (90 feet). Those creatures regain\n8d8 + 11 hit points. Each of those creatures recover from all Conditions."
         }
       ],
-      "background": "Vohu Manah is the \"good\" state of mind that accomplishes duty who appears in Zoroastrian mythology. He is one of the six Amesha Spentas of Zoroastrianism. He represents all animals from creation, especially cattle. Vohu Manah is of neutral gender in Avestan grammar but in Zoroastrian tradition is considered masculine. The second day of every month and the eleventh month are dedicated to him. His eternal opponent is the demon of evil thought, Aka Manah.\n"
+      "background": "Vohu Manah is the \"good\" state of mind that accomplishes duty who appears in Zoroastrian mythology. He is one of the six Amesha Spentas of Zoroastrianism. He represents all animals from creation, especially cattle. Vohu Manah is of neutral gender in Avestan grammar but in Zoroastrian tradition is considered masculine. The second day of every month and the eleventh month are dedicated to him. His eternal opponent is the demon of evil thought, Aka Manah."
     },
     {
-      "name": "Zaou-Gongen",
+      "name": "zaou-gongen",
+      "displayName": "Zaou-Gongen",
       "evolvesTo": null,
       "primaryElement": "Fire",
       "level": "27",
@@ -11817,11 +12006,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 2d8 + 5 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 2d8 + 5 physical damage."
         },
         {
           "name": "Blazing Hell (24 SP, 2 actions)",
-          "description": "You unleash a massive swathe of magmatic force, disintegrating and melting all matter and unlucky enemies caught within the area with a high chance of Burn. Make a ranged attack against each creature within a 20-feet sphere centered at a point within range \u000b(-1 to hit, 20 feet). On a hit, they receive 4d8 + 3 fire damage. If each d6 in the attack roll is a 3 or higher, the target is also Burned (see \u201cConditions\u201d)."
+          "description": "You unleash a massive swathe of magmatic force, disintegrating and melting all matter and unlucky enemies caught within the area with a high chance of Burn. Make a ranged attack against each creature within a 20-feet sphere centered at a point within range\n(-1 to hit, 20 feet). On a hit, they receive 4d8 + 3 fire damage. If each d6 in the attack roll is a 3 or higher, the target is also Burned (see \u201cConditions\u201d)."
         },
         {
           "name": "Abysmal Surge (10 SP, 2 actions)",
@@ -11835,7 +12024,8 @@
       "background": "Zaou-Gongen (\u8535\u738b\u6a29\u73fe*)?, also known as Vajragarbha, is one of the most important mountain deities of Japan's syncretic Shugendo sects founded by En no Ozuno. They are a diverse tradition of mountain ascetic practices associated with Shinto beliefs, Taoism, magic, supernatural powers and Esoteric (Tantric) Buddhism. After the arrival of Buddhism to Japan in the mid-6th century, the native Shinto Kami were soon considered manifestations of the imported Buddhist divinities. Zaou serves as the protector deity of sacred Mt. Kimpusen Japan's Nara prefecture and is considered the local Japanese Shinto manifestation of three Buddhist divinities: the Historical Buddha, Kannon Bodhisattva and Miroku Buddha, who served respectively as the Buddhas of the Past, Present and Future. This makes Zaou perhaps the most powerful local divinity of religious mountain worship in Japan."
     },
     {
-      "name": "Alice",
+      "name": "alice",
+      "displayName": "Alice",
       "evolvesTo": null,
       "primaryElement": "Curse",
       "level": "28",
@@ -11878,13 +12068,13 @@
         },
         {
           "name": "Survival Trick",
-          "description": "With deceit and trickery, as well as resilience, you are able to avoid disaster. You gain the following benefits:\n \u2022 When you would be reduced to 0 hit points by a Hama or Mudo type Skill, or Door of Hades, you are reduced to 1 hit points instead.\n \u2022 When you would be reduced to 0 hit points by a hostile attack that is not a Hama or Mudo type Skill, or Door of Hades , you are reduced to 1 hit point instead. Once this ability is used, you cannot use it again until you fully recover in Reality. "
+          "description": "With deceit and trickery, as well as resilience, you are able to avoid disaster. You gain the following benefits:\n\u2022 When you would be reduced to 0 hit points by a Hama or Mudo type Skill, or Door of Hades, you are reduced to 1 hit points instead.\n\u2022 When you would be reduced to 0 hit points by a hostile attack that is not a Hama or Mudo type Skill, or Door of Hades , you are reduced to 1 hit point instead. Once this ability is used, you cannot use it again until you fully recover in Reality. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 2d4 + 3 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 2d4 + 3 physical damage."
         },
         {
           "name": "Die for Me! (0 SP, 2 actions)",
@@ -11896,13 +12086,14 @@
         },
         {
           "name": "Megidolaon (36 SP, 2 actions)",
-          "description": "A flash of light. A singularity instantly expands, as a reality-busting sphere of destructive energy emerges from the ground, blinding and erasing all. Make a ranged attack against each creature within a 20-foot radius sphere centered at a point within range \u000b(-1 to hit, 20 feet). On a hit, a creature receives 4d8 + 5 almighty damage."
+          "description": "A flash of light. A singularity instantly expands, as a reality-busting sphere of destructive energy emerges from the ground, blinding and erasing all. Make a ranged attack against each creature within a 20-foot radius sphere centered at a point within range\n(-1 to hit, 20 feet). On a hit, a creature receives 4d8 + 5 almighty damage."
         }
       ],
-      "background": "Alice's appearance is based off of the titular character of Alice in Wonderland, while her personality and demeanor derive from a European folk tale, used to scare children into behaving.\n In Lewis Carroll's Alice in Wonderland and its sequel, Alice is a young girl attempting to escape boredom. After chasing a talking rabbit down a rabbit hole, she ends up in a nonsensical fantasy world populated by anthropomorphic animals, personified playing cards, and the Hatter, who hosts a never-ending \"mad tea-party.\" The character Alice herself is said to be taken from Alice Pleasance Liddell, a little girl who was close to Carroll.\n"
+      "background": "Alice's appearance is based off of the titular character of Alice in Wonderland, while her personality and demeanor derive from a European folk tale, used to scare children into behaving.\n\nIn Lewis Carroll's Alice in Wonderland and its sequel, Alice is a young girl attempting to escape boredom. After chasing a talking rabbit down a rabbit hole, she ends up in a nonsensical fantasy world populated by anthropomorphic animals, personified playing cards, and the Hatter, who hosts a never-ending \"mad tea-party.\" The character Alice herself is said to be taken from Alice Pleasance Liddell, a little girl who was close to Carroll."
     },
     {
-      "name": "Ardha",
+      "name": "ardha",
+      "displayName": "Ardha",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "28",
@@ -11939,17 +12130,17 @@
       "traits": [
         {
           "name": "Speed Master",
-          "description": "You have a unique sense for agile tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Sukukaja Skill at no cost or action."
+          "description": "You have a unique sense for agile tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Sukukaja Skill at no cost or action."
         },
         {
           "name": "Apt Pupil",
-          "description": "Your skill and cunning allows you to avoid the worst of impacts. You gain the following benefits:\n \u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n \u2022 You score a critical hit for attacks where all d6s in the attack roll are a 2 or less. "
+          "description": "Your skill and cunning allows you to avoid the worst of impacts. You gain the following benefits:\n\u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n\u2022 You score a critical hit for attacks where all d6s in the attack roll are a 2 or less. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 2d4 + 5 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 2d4 + 5 physical damage."
         },
         {
           "name": "Agneyastra (17 HP, 2 actions)",
@@ -11957,17 +12148,18 @@
         },
         {
           "name": "Cosmic Flare (24 SP, 2 actions)",
-          "description": "A target is subject to a nova-level, concentrated orb of raw nuclear energy, Make a ranged attack against each creature within a 30 feet radius sphere centered at a point within range \u000b(-1 to hit, 30 feet). On a hit, they receive 4d8 + 5 nuke damage."
+          "description": "A target is subject to a nova-level, concentrated orb of raw nuclear energy, Make a ranged attack against each creature within a 30 feet radius sphere centered at a point within range\n(-1 to hit, 30 feet). On a hit, they receive 4d8 + 5 nuke damage."
         },
         {
           "name": "Salvation (60 SP, 2 actions)",
-          "description": "Divine will invigorates you and your allies. Choose up to six creatures within range (90 feet). Those creatures regain \u000b8d8 + 10 hit points. Each of those creatures recover from all Conditions."
+          "description": "Divine will invigorates you and your allies. Choose up to six creatures within range (90 feet). Those creatures regain\n8d8 + 10 hit points. Each of those creatures recover from all Conditions."
         }
       ],
-      "background": "The term \"Ardhanarishvara\" is a combination of three words- \"ardha,\" \"nari\" and \"ishvara,\" meaning respectively, \"half,\" \"woman\" and \"lord\" or \"god,\" that is, Ardhanarishvara is the Lord Who is Half Woman. The god is male on one side and female on the other, depicted with the male half bearing aspects of Shiva and the female half bearing aspects of Parvati. It is one of the most common forms of the divine in Indian art and the figure itself is likely older than the many stories and myths that have formed around it. In some texts, Ardhanarishvara is an androgynous incarnation of Shiva, in others it is the form of Shiva and Parvati, who loved each other so deeply that they joined as one being rather than stay apart.\n"
+      "background": "The term \"Ardhanarishvara\" is a combination of three words- \"ardha,\" \"nari\" and \"ishvara,\" meaning respectively, \"half,\" \"woman\" and \"lord\" or \"god,\" that is, Ardhanarishvara is the Lord Who is Half Woman. The god is male on one side and female on the other, depicted with the male half bearing aspects of Shiva and the female half bearing aspects of Parvati. It is one of the most common forms of the divine in Indian art and the figure itself is likely older than the many stories and myths that have formed around it. In some texts, Ardhanarishvara is an androgynous incarnation of Shiva, in others it is the form of Shiva and Parvati, who loved each other so deeply that they joined as one being rather than stay apart."
     },
     {
-      "name": "Cybele",
+      "name": "cybele",
+      "displayName": "Cybele",
       "evolvesTo": null,
       "primaryElement": "Healing",
       "level": "28",
@@ -12005,17 +12197,17 @@
       "traits": [
         {
           "name": "Linked Bloodline (Bless)",
-          "description": "Power is handed down from prior efforts, be it ancestral or from allies in the moment. You gain the following benefits:\n \u2022 When you gain this Trait, choose Fire, Ice, Electric, Wind, Psychic, Nuke, Bless, or Curse. The Spell Point cost of Skills that are of the chosen type is halved, to a minimum of 1.\n \u2022 Whenever you roll for a damage roll with an attack made using an action granted by a Baton Pass, you may add your character level to the damage roll."
+          "description": "Power is handed down from prior efforts, be it ancestral or from allies in the moment. You gain the following benefits:\n\u2022 When you gain this Trait, choose Fire, Ice, Electric, Wind, Psychic, Nuke, Bless, or Curse. The Spell Point cost of Skills that are of the chosen type is halved, to a minimum of 1.\n\u2022 Whenever you roll for a damage roll with an attack made using an action granted by a Baton Pass, you may add your character level to the damage roll."
         },
         {
           "name": "Defense Master",
-          "description": "You have a unique sense for defensive tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Rakukaja Skill at no cost or action. "
+          "description": "You have a unique sense for defensive tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Rakukaja Skill at no cost or action. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 3 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 3 physical damage."
         },
         {
           "name": "Samarecarm (28 SP, 1 action)",
@@ -12023,17 +12215,18 @@
         },
         {
           "name": "Salvation (60 SP, 2 actions)",
-          "description": "Divine will invigorates you and your allies. Choose up to six creatures within range (90 feet). Those creatures regain \u000b8d8 + 10 hit points. Each of those creatures recover from all Conditions."
+          "description": "Divine will invigorates you and your allies. Choose up to six creatures within range (90 feet). Those creatures regain\n8d8 + 10 hit points. Each of those creatures recover from all Conditions."
         },
         {
           "name": "Kougaon (8 SP, 1 action)",
           "description": "You invoke holy will, and a cascading pillar of light and holy magic erupts from the foe\u2019s space. Make a ranged attack against a creature within range (-1 to hit, 60 feet). On a hit, they receive 4d8 + 5 bless damage."
         }
       ],
-      "background": "Cybele is the deity of Phrygia, a realm in ancient Anatolia, that represents the idea of a mother goddess, similar to Gaia of the Greeks. Cybele is also associated with various natural elements, including wildlife and vegetation. Wild cats in particular were often associated with her. It's possible she was derived from an earlier mostly Hittite goddess, Kubaba.\n In Greece, Cybele was a protector of several city-states, one of which is Athens. Her most celebrated Greek rites and processions showed her as a foreign and exotic mystery-goddess. She arrives in a lion-drawn chariot to the accompaniment of wild music, wine and a disorderly, ecstatic following. She was unique among deities worshiped by the Greeks as she had a transgendered, or eunuch, priesthood. Many of her Greek cults included rites to a divine, castrated, Phrygian shepherd-consort known as Attis. She is associated with mountains, town and city walls, fertile nature and wild animals, namely lions."
+      "background": "Cybele is the deity of Phrygia, a realm in ancient Anatolia, that represents the idea of a mother goddess, similar to Gaia of the Greeks. Cybele is also associated with various natural elements, including wildlife and vegetation. Wild cats in particular were often associated with her. It's possible she was derived from an earlier mostly Hittite goddess, Kubaba.\n\nIn Greece, Cybele was a protector of several city-states, one of which is Athens. Her most celebrated Greek rites and processions showed her as a foreign and exotic mystery-goddess. She arrives in a lion-drawn chariot to the accompaniment of wild music, wine and a disorderly, ecstatic following. She was unique among deities worshiped by the Greeks as she had a transgendered, or eunuch, priesthood. Many of her Greek cults included rites to a divine, castrated, Phrygian shepherd-consort known as Attis. She is associated with mountains, town and city walls, fertile nature and wild animals, namely lions."
     },
     {
-      "name": "Ishtar",
+      "name": "ishtar",
+      "displayName": "Ishtar",
       "evolvesTo": null,
       "primaryElement": "Healing",
       "level": "28",
@@ -12079,7 +12272,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Salvation (30 SP, 2 actions)",
@@ -12091,13 +12284,14 @@
         },
         {
           "name": "Ziodyne (16 SP, 1 action)",
-          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (-1 to hit, 30 feet). On a hit, they receive \u000b3d8 + 5 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
+          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (-1 to hit, 30 feet). On a hit, they receive\n3d8 + 5 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
         }
       ],
       "background": "Ishtar is the Akkadian (and thus later Babylonian and Assyrian) equivalent of the Sumerian goddess Inanna and shares her roles as a goddess of love, war and fertility. Like Inanna, she wasn't considered a mother goddess, and few, if any, texts name any gods as her children. She is known as the \"Queen of Heaven\" and is the personification of the morning star (Venus). Her father is usually said to be Sin, the moon god, and she forms an astral trinity with him and her twin brother Shamash, the sun god. Other texts sometimes refer to Anu, Enlil or Ea (Enki) as her father. She is also known as the \"Lady of Battles\" because of her violent and warlike character. Her holy city was Uruk (or Erech). Part of her cult was thought to be devoted to temple prostitution, though despite Ishtar's sexual character, some modern researchers question this claim or the scope of such practices. Her symbols were the eight pointed star (originally simply a Mesopotamian symbol of heaven, but in later times only of the morning star), the lion and the dove. Like most Mesopotamian gods, art often depicts her wearing a horned crown, a symbol of divinity. She was commonly depicted as winged."
     },
     {
-      "name": "Fafnir",
+      "name": "fafnir",
+      "displayName": "Fafnir",
       "evolvesTo": null,
       "primaryElement": "Nuke",
       "level": "28",
@@ -12141,13 +12335,13 @@
         },
         {
           "name": "Hollow Jester",
-          "description": "You seek out the weak-willed and the ailing pack. You gain the following benefits:\n \u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n \u2022 You may add half your character level (min 1) to the damage roll of any attack against a target afflicted with a Condition. You may add this bonus multiple times, once for each Condition the target is inflicted with. "
+          "description": "You seek out the weak-willed and the ailing pack. You gain the following benefits:\n\u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n\u2022 You may add half your character level (min 1) to the damage roll of any attack against a target afflicted with a Condition. You may add this bonus multiple times, once for each Condition the target is inflicted with. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 2d8 + 5 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 2d8 + 5 physical damage."
         },
         {
           "name": "Cosmic Flare (24 SP, 2 actions)",
@@ -12162,10 +12356,11 @@
           "description": "A tectonic force crumbles and fissures the earth, unleashing pure destruction on your foes. Make a melee attack against each creature within a 20-foot sphere centered at a point within range (-1 to hit, 20 feet). A creature hit by this attack receives 6d8 + 5 physical damage."
         }
       ],
-      "background": "Fafnir was the son of the dwarf king Hreidmar, and the brother of Regin and \u00d3tr in Norse mythology.\n After \u00d3tr was killed by Loki, Hreidmar received the cursed gold of the dwarf Andvari's as repayment for the loss of his son. Fafnir and Regin then killed their father to get the gold, but Fafnir decided he wanted it all, becoming a dragon (symbol of greed). Regin then sent his foster-son, Sigurd, to kill the dragon. Sigurd succeeded by digging a pit under the trail F\u00e1fnir used to walk to a stream and plunging his sword Gram into his heart as he walked past. Regin, however, corrupted by the curse of Andvari's gold, planned to kill Sigurd to take the treasure for himself, but Sigurd, having eaten part of Fafnir's cooked heart, was warned by birds of Regin's attack and ended up killing him.\n"
+      "background": "Fafnir was the son of the dwarf king Hreidmar, and the brother of Regin and \u00d3tr in Norse mythology.\n\nAfter \u00d3tr was killed by Loki, Hreidmar received the cursed gold of the dwarf Andvari's as repayment for the loss of his son. Fafnir and Regin then killed their father to get the gold, but Fafnir decided he wanted it all, becoming a dragon (symbol of greed). Regin then sent his foster-son, Sigurd, to kill the dragon. Sigurd succeeded by digging a pit under the trail F\u00e1fnir used to walk to a stream and plunging his sword Gram into his heart as he walked past. Regin, however, corrupted by the curse of Andvari's gold, planned to kill Sigurd to take the treasure for himself, but Sigurd, having eaten part of Fafnir's cooked heart, was warned by birds of Regin's attack and ended up killing him."
     },
     {
-      "name": "Hastur",
+      "name": "hastur",
+      "displayName": "Hastur",
       "evolvesTo": null,
       "primaryElement": "Almighty",
       "level": "28",
@@ -12214,7 +12409,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 4 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 4 physical damage."
         },
         {
           "name": "Abyssal Eye (36 SP, 2 actions)",
@@ -12222,17 +12417,18 @@
         },
         {
           "name": "Vacuum Wave (20 SP, 2 actions)",
-          "description": "A natural disaster traps a field in a typhoon of destruction and howling gales. Make a ranged attack against each creature within a 20-feet sphere centered at a point within range \u000b(-1 to hit, 20 feet). On a hit, they receive 8d8 + 5 wind damage."
+          "description": "A natural disaster traps a field in a typhoon of destruction and howling gales. Make a ranged attack against each creature within a 20-feet sphere centered at a point within range\n(-1 to hit, 20 feet). On a hit, they receive 8d8 + 5 wind damage."
         },
         {
           "name": "Debilitate (18 SP, 1 action)",
           "description": "You forcibly impose baleful curses upon a foe, decreasing its overall combat performance. Choose a creature within range (90 feet). This creature gains the effects of Tarunda, Rakunda, and Sukunda."
         }
       ],
-      "background": "While Hastur is best known as part of the Cthulhu Mythos, he was originally created by Ambrose Bierce in the short story \"Haita The Shepherd.\" He later appeared in one work by HP Lovecraft, but is best known for his role in August Derleth's stories. Hastur is the half-brother of Cthulhu.\n He is also known in other names:\n The Feaster from Afar, a black, shriveled, flying monstrosity with tentacles tipped with razor-sharp talons that can pierce a victim's skull and siphon out the brain\n The King in Yellow\n He Who Is Not To Be Named as saying Hastur's name three times in a row (Hastur Hastur Hastur) brings the chanter death.\n The King In Yellow is also the title of a fictional stage play within the Cthulhu Mythos, where Hastur is mentioned, as well as a real-life short story collection in which the stage play appears several times. Hastur's Material Card features the cover of this book.\n"
+      "background": "While Hastur is best known as part of the Cthulhu Mythos, he was originally created by Ambrose Bierce in the short story \"Haita The Shepherd.\" He later appeared in one work by HP Lovecraft, but is best known for his role in August Derleth's stories. Hastur is the half-brother of Cthulhu.\n\nHe is also known in other names:\n\nThe Feaster from Afar, a black, shriveled, flying monstrosity with tentacles tipped with razor-sharp talons that can pierce a victim's skull and siphon out the brain\n\nThe King in Yellow\n\nHe Who Is Not To Be Named as saying Hastur's name three times in a row (Hastur Hastur Hastur) brings the chanter death.\n\nThe King In Yellow is also the title of a fictional stage play within the Cthulhu Mythos, where Hastur is mentioned, as well as a real-life short story collection in which the stage play appears several times. Hastur's Material Card features the cover of this book."
     },
     {
-      "name": "Mother Harlot",
+      "name": "mother-harlot",
+      "displayName": "Mother Harlot",
       "evolvesTo": null,
       "primaryElement": "Ice",
       "level": "28",
@@ -12280,7 +12476,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 2d4 + 5 physical damage. Attacks three times."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 2d4 + 5 physical damage. Attacks three times."
         },
         {
           "name": "Ice Age (24 SP, 2 actions)",
@@ -12295,10 +12491,11 @@
           "description": "You forcibly impose baleful curses upon a foe, decreasing its overall combat performance. Choose a creature within range (90 feet). This creature gains the effects of Tarunda, Rakunda, and Sukunda."
         }
       ],
-      "background": "Mother Harlot, also known as \"Babylon the Great, Mother of Prostitutes and Abominations of the Earth,\" \"the Whore of Babylon\" or the Harlot for short, is an allegorical and apocalyptic figure of evil and one of several incarnations of evil that is said to plague the world during the end days as written in the Book of Revelation, She is depicted as a beautiful woman who is \"the mother of all harlots and of all abominations of the world.\" While incredibly powerful and terrifying, she is destined to meet her end at the hands of The Beast as part of the apocalypse.\n She appears as wearing a purple robe. The color purple was associated with the Roman Empire. The beast she rides has seven heads and Rome has seven hills, so the heads could reflect the ancient power of Rome, which traditionally was one of antiquity's most powerful empires. Alternatively, the heads of the beast could represent the seven great kingdoms of the ancient world and their rulers.\n"
+      "background": "Mother Harlot, also known as \"Babylon the Great, Mother of Prostitutes and Abominations of the Earth,\" \"the Whore of Babylon\" or the Harlot for short, is an allegorical and apocalyptic figure of evil and one of several incarnations of evil that is said to plague the world during the end days as written in the Book of Revelation, She is depicted as a beautiful woman who is \"the mother of all harlots and of all abominations of the world.\" While incredibly powerful and terrifying, she is destined to meet her end at the hands of The Beast as part of the apocalypse.\n\nShe appears as wearing a purple robe. The color purple was associated with the Roman Empire. The beast she rides has seven heads and Rome has seven hills, so the heads could reflect the ancient power of Rome, which traditionally was one of antiquity's most powerful empires. Alternatively, the heads of the beast could represent the seven great kingdoms of the ancient world and their rulers."
     },
     {
-      "name": "Odin",
+      "name": "odin",
+      "displayName": "Odin",
       "evolvesTo": null,
       "primaryElement": "Electric",
       "level": "28",
@@ -12347,7 +12544,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Thunder Reign (24 SP, 1 action)",
@@ -12362,10 +12559,11 @@
           "description": "You gather and focus your mind's eye, delivering an absolute force of will. The next damage roll you make for an attack that deals Fire, Ice, Electric, Wind, Psychic, Nuke, Bless, Curse, or Almighty damage within the next 10 minutes is doubled."
         }
       ],
-      "background": "Odin (Old Norse: \u00d3\u00f0inn), meaning The Furious, is considered the chief god (known as an All-Father) of the Aesir (and sometimes the Vanir as well) in Norse mythology. He is associated with wisdom, war, frenzy, knowledge, battle and death and also magic, sorcery, poetry, the gallows, healing, royalty, prophecy, victory and the hunt, and is the husband of the goddess Frigg.\n Odin is often portrayed as being an eminently honorable ruler and battlefield commander, but to the ancient Norse, he was nothing of the sort. In contrast to more straightforwardly noble war gods such as Tyr or Thor, Odin incites otherwise peaceful people to strife with what is a downright sinister glee. He maintains particularly close affiliations with the berserkers and other \u201cwarrior-shamans\u201d who's fighting techniques and associated spiritual practices center around achieving a state of ecstatic unification with certain ferocious totem animals. He is also known by hundreds of names some which includes: Wodan, Aldagautr, Biflindi, Bileygr, Draugadr\u00f3ttinn, Dr\u00f3ttinn, Fengr, Fj\u00f6lnir, Forni, Gr\u00edmnir, Hangi, H\u00e1vi, J\u00f6lnir and Vegtam.\n"
+      "background": "Odin (Old Norse: \u00d3\u00f0inn), meaning The Furious, is considered the chief god (known as an All-Father) of the Aesir (and sometimes the Vanir as well) in Norse mythology. He is associated with wisdom, war, frenzy, knowledge, battle and death and also magic, sorcery, poetry, the gallows, healing, royalty, prophecy, victory and the hunt, and is the husband of the goddess Frigg.\n\nOdin is often portrayed as being an eminently honorable ruler and battlefield commander, but to the ancient Norse, he was nothing of the sort. In contrast to more straightforwardly noble war gods such as Tyr or Thor, Odin incites otherwise peaceful people to strife with what is a downright sinister glee. He maintains particularly close affiliations with the berserkers and other \u201cwarrior-shamans\u201d who's fighting techniques and associated spiritual practices center around achieving a state of ecstatic unification with certain ferocious totem animals. He is also known by hundreds of names some which includes: Wodan, Aldagautr, Biflindi, Bileygr, Draugadr\u00f3ttinn, Dr\u00f3ttinn, Fengr, Fj\u00f6lnir, Forni, Gr\u00edmnir, Hangi, H\u00e1vi, J\u00f6lnir and Vegtam."
     },
     {
-      "name": "Siegfried",
+      "name": "siegfried",
+      "displayName": "Siegfried",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "28",
@@ -12405,17 +12603,17 @@
       "traits": [
         {
           "name": "Retaliating Body",
-          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n \u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n \u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled."
+          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n\u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n\u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled."
         },
         {
           "name": "Apt Pupil",
-          "description": "Your skill and cunning allows you to avoid the worst of impacts. You gain the following benefits:\n \u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n \u2022 You score a critical hit for attacks where all d6s in the attack roll are a 2 or less. "
+          "description": "Your skill and cunning allows you to avoid the worst of impacts. You gain the following benefits:\n\u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n\u2022 You score a critical hit for attacks where all d6s in the attack roll are a 2 or less. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Vorpal Blade (10 HP, 1 action)",
@@ -12430,10 +12628,11 @@
           "description": "You begin amassing your strength and stamina, coalescing into an ultimate strike. The next damage roll you make for an attack that deals Physical or Gun damage within the next 10 minutes is doubled."
         }
       ],
-      "background": "Siegfried is the dragon-slaying hero of the medieval German epic Das Nibelungenlied, most widely known due to its adaptation by Richard Wagner into a series of four operas, Der Ring des Nibelungen.\n Sigurd was requested to slay Fafnir by Regin, his foster parent and guardian. Regin was the brother of Otr and Fafnir and son of Hreidmar. Otr was killed by the Aesir after they mistook him for an otter, and as compensation had his body stuffed with gold. Fafnir then killed Hreidmar and stole the \"Otr's Gold,\" and to better guard it, turned himself into a dragon.\n Sigurd met Odin on his way, who advised the hero to dig trenches to drain the dragon's blood, which apparently gave him invulnerability. He killed Fafnir when the dragon walked over the trench, and bathed himself in the blood. However, a leaf had fallen and stuck itself on his shoulder. When he drank some of the blood, he understood the language of the birds and learned that Regin was plotting his death. As retaliation, he killed Regin first. Despite gaining the gold, however, it brought him no happiness."
+      "background": "Siegfried is the dragon-slaying hero of the medieval German epic Das Nibelungenlied, most widely known due to its adaptation by Richard Wagner into a series of four operas, Der Ring des Nibelungen.\n\nSigurd was requested to slay Fafnir by Regin, his foster parent and guardian. Regin was the brother of Otr and Fafnir and son of Hreidmar. Otr was killed by the Aesir after they mistook him for an otter, and as compensation had his body stuffed with gold. Fafnir then killed Hreidmar and stole the \"Otr's Gold,\" and to better guard it, turned himself into a dragon.\n\nSigurd met Odin on his way, who advised the hero to dig trenches to drain the dragon's blood, which apparently gave him invulnerability. He killed Fafnir when the dragon walked over the trench, and bathed himself in the blood. However, a leaf had fallen and stuck itself on his shoulder. When he drank some of the blood, he understood the language of the birds and learned that Regin was plotting his death. As retaliation, he killed Regin first. Despite gaining the gold, however, it brought him no happiness."
     },
     {
-      "name": "Surt",
+      "name": "surt",
+      "displayName": "Surt",
       "evolvesTo": null,
       "primaryElement": "Fire",
       "level": "28",
@@ -12474,7 +12673,7 @@
       "traits": [
         {
           "name": "Attack Master",
-          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n \u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n \u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action."
+          "description": "You have a unique sense for offensive tactics. You gain the following benefits:\n\u2022 Whenever you roll for initiative, you may add a +5 bonus to the roll.\n\u2022 Whenever you roll for initiative, you gain the effects of the Tarukaja Skill at no cost or action."
         },
         {
           "name": "Elemental Amp (Fire)",
@@ -12484,7 +12683,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 2d8 + 5 fire damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 2d8 + 5 fire damage."
         },
         {
           "name": "Ragnarok (36 SP, 2 actions)",
@@ -12499,10 +12698,11 @@
           "description": "You expose the weakest points of a group of foes, allowing for allies to move in. Choose up to six creatures within range (90 feet). Those creatures gain the effects of Rakunda."
         }
       ],
-      "background": "In Norse mythology, Surt (more commonly known as Surtr) rules the land of fire, Muspelheim, guarding the entrance of this realm with his shining sword, Laevateinn, that is said to be brighter than the sun. It is also said to be the creator and the destroyer, as the fires of his realm created the stars of the heavens, and later during Ragnarok, it will rain down fire onto all land.\n"
+      "background": "In Norse mythology, Surt (more commonly known as Surtr) rules the land of fire, Muspelheim, guarding the entrance of this realm with his shining sword, Laevateinn, that is said to be brighter than the sun. It is also said to be the creator and the destroyer, as the fires of his realm created the stars of the heavens, and later during Ragnarok, it will rain down fire onto all land."
     },
     {
-      "name": "Vishnu",
+      "name": "vishnu",
+      "displayName": "Vishnu",
       "evolvesTo": null,
       "primaryElement": "Wind",
       "level": "28",
@@ -12551,25 +12751,26 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 2d4 + 5 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 2d4 + 5 physical damage."
         },
         {
           "name": "Vacuum Wave (10 SP, 2 actions)",
-          "description": "A natural disaster traps a field in a typhoon of destruction and howling gales. Make a ranged attack against each creature within a 20-feet sphere centered at a point within range \u000b(-1 to hit, 20 feet). On a hit, they receive 8d8 + 5 wind damage."
+          "description": "A natural disaster traps a field in a typhoon of destruction and howling gales. Make a ranged attack against each creature within a 20-feet sphere centered at a point within range\n(-1 to hit, 20 feet). On a hit, they receive 8d8 + 5 wind damage."
         },
         {
           "name": "Megidolaon (36 SP, 2 actions)",
-          "description": "A flash of light. A singularity instantly expands, as a reality-busting sphere of destructive energy emerges from the ground, blinding and erasing all. Make a ranged attack against each creature within a 20-foot radius sphere centered at a point within range \u000b(-1 to hit, 20 feet). On a hit, a creature receives 4d8 + 5 almighty damage."
+          "description": "A flash of light. A singularity instantly expands, as a reality-busting sphere of destructive energy emerges from the ground, blinding and erasing all. Make a ranged attack against each creature within a 20-foot radius sphere centered at a point within range\n(-1 to hit, 20 feet). On a hit, a creature receives 4d8 + 5 almighty damage."
         },
         {
           "name": "Riot Gun (12 HP, 2 actions)",
-          "description": "A shower of piercing shots rain from the heavens above, turning foes into ribbons. Make a ranged attack against each creature within a 20-feet sphere, centered at a point within range \u000b(-1 to hit, 60 feet). On a hit, the creature receives 5d10 + 5 gun damage."
+          "description": "A shower of piercing shots rain from the heavens above, turning foes into ribbons. Make a ranged attack against each creature within a 20-feet sphere, centered at a point within range\n(-1 to hit, 60 feet). On a hit, the creature receives 5d10 + 5 gun damage."
         }
       ],
-      "background": "Vishnu, rarely known as Adideva, is one of the primary deities in the Hindu pantheon. He is called The Preserver and is known for a kindly demeanor and genuine interest in the welfare of humanity. In the Hindu religion, Vishnu the Preserver is one of the three principal deities of the Trimurti (Hindu male Triad) along with Brahma, the Creator, and Shiva, the Destroyer. He was first seen in early Vedic mythology as the god that assisted Indra in defeating Vritra and is now the supreme deity within Vaishnavism, a branch of Hinduism that focuses on the worship of Vishnu. As the preserver, Vishnu maintains balance within the world, and at the end of our current era he will appear as his final avatar Kalki and judge whether mortals have been good or evil. After this, the universe will end and creation will start anew. He is depicted with up to four arms, blue skin, holding a chakra wheel, a lotus flower, a mace and a conch, and rides on the back of Garuda. He also sleeps on the back of a great Naga named Ananta Shesha.\n"
+      "background": "Vishnu, rarely known as Adideva, is one of the primary deities in the Hindu pantheon. He is called The Preserver and is known for a kindly demeanor and genuine interest in the welfare of humanity. In the Hindu religion, Vishnu the Preserver is one of the three principal deities of the Trimurti (Hindu male Triad) along with Brahma, the Creator, and Shiva, the Destroyer. He was first seen in early Vedic mythology as the god that assisted Indra in defeating Vritra and is now the supreme deity within Vaishnavism, a branch of Hinduism that focuses on the worship of Vishnu. As the preserver, Vishnu maintains balance within the world, and at the end of our current era he will appear as his final avatar Kalki and judge whether mortals have been good or evil. After this, the universe will end and creation will start anew. He is depicted with up to four arms, blue skin, holding a chakra wheel, a lotus flower, a mace and a conch, and rides on the back of Garuda. He also sleeps on the back of a great Naga named Ananta Shesha."
     },
     {
-      "name": "Chi You",
+      "name": "chi-you",
+      "displayName": "Chi You",
       "evolvesTo": null,
       "primaryElement": "Psychic",
       "level": "29",
@@ -12618,7 +12819,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -3 to hit, range 5 ft., one target. \u000bHit: 2d8 + 5 physical damage."
+          "description": "Melee attack: -3 to hit, range 5 ft., one target.\nHit: 2d8 + 5 physical damage."
         },
         {
           "name": "Psycho Blast (24 SP, 2 actions)",
@@ -12633,10 +12834,11 @@
           "description": "You gather and focus your mind's eye, delivering an absolute force of will. The next damage roll you make for an attack that deals Fire, Ice, Electric, Wind, Psychic, Nuke, Bless, Curse, or Almighty damage within the next 10 minutes is doubled."
         }
       ],
-      "background": "Chiyou (\u86a9\u5c24) is a deity in Chinese mythology that descended from Shennong (\u795e\u8fb2), emperor of fire and agriculture. This half-man, half-bull war deity helped and led the Hmong and Li Tribes fight against Huang Di: the king who is said to be the ancestor of all Han Chinese. Huang Di lost many of his initial battles with Chiyou but won the final battle with the invention of the south pointing chariot (a mechanical compass without magnet) that allowed him to navigate through the thick fog summoned by Chiyou's forces. Chiyou was then beheaded by Yinglong (\u61c9\u9f8d), one of the Yellow Emperor's top generals.\n He is worshiped in China as the god of war and weapons and, along with Huang Di, as one of the progenitors of the Chinese people. Qin Shi Huang (\u79e6\u59cb\u7687), the First Emperor of China, worshiped Chiyou and attributed him to his success in conquering his rival states. Liu Bang (\u5289\u90a6), the founder of the Han dynasty, was also noted to have worshiped at Chiyou's shrine before his decisive battle with Xiang Yu (\u9805\u7fbd)."
+      "background": "Chiyou (\u86a9\u5c24) is a deity in Chinese mythology that descended from Shennong (\u795e\u8fb2), emperor of fire and agriculture. This half-man, half-bull war deity helped and led the Hmong and Li Tribes fight against Huang Di: the king who is said to be the ancestor of all Han Chinese. Huang Di lost many of his initial battles with Chiyou but won the final battle with the invention of the south pointing chariot (a mechanical compass without magnet) that allowed him to navigate through the thick fog summoned by Chiyou's forces. Chiyou was then beheaded by Yinglong (\u61c9\u9f8d), one of the Yellow Emperor's top generals.\n\nHe is worshiped in China as the god of war and weapons and, along with Huang Di, as one of the progenitors of the Chinese people. Qin Shi Huang (\u79e6\u59cb\u7687), the First Emperor of China, worshiped Chiyou and attributed him to his success in conquering his rival states. Liu Bang (\u5289\u90a6), the founder of the Han dynasty, was also noted to have worshiped at Chiyou's shrine before his decisive battle with Xiang Yu (\u9805\u7fbd)."
     },
     {
-      "name": "Futsunushi",
+      "name": "futsunushi",
+      "displayName": "Futsunushi",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "29",
@@ -12672,17 +12874,17 @@
       "traits": [
         {
           "name": "Will of the Sword",
-          "description": "A properly harnessed will and strength is unopposed. You gain the following benefits:\n \u2022 Whenever you roll Initiative, flip a coin. If heads, you gain the benefits of Power Charge and Concentrate at no cost.\n \u2022 You may add 2d8 to the damage roll of an attack benefiting from Power Charge or Concentrate."
+          "description": "A properly harnessed will and strength is unopposed. You gain the following benefits:\n\u2022 Whenever you roll Initiative, flip a coin. If heads, you gain the benefits of Power Charge and Concentrate at no cost.\n\u2022 You may add 2d8 to the damage roll of an attack benefiting from Power Charge or Concentrate."
         },
         {
           "name": "Firm Stance",
-          "description": "Resilience and durability allow you to stand firm against all threats. You gain the following benefits:\n \u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n \u2022 When you are subjected to an attack, you may choose to use this ability. If you do, you cannot evade the attack, and you receive half as much damage from it. "
+          "description": "Resilience and durability allow you to stand firm against all threats. You gain the following benefits:\n\u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n\u2022 When you are subjected to an attack, you may choose to use this ability. If you do, you cannot evade the attack, and you receive half as much damage from it. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Brave Blade (10 HP, 1 action)",
@@ -12697,10 +12899,11 @@
           "description": "You begin amassing your strength and stamina, coalescing into an ultimate strike. The next damage roll you make for an attack that deals Physical or Gun damage within the next 10 minutes is doubled."
         }
       ],
-      "background": "Futsunushi-no-kami (\u7d4c\u6d25\u4e3b\u795e) is a Shinto deity of swords. He is regarded as the personification of the sword Futsu-no-mitama.\n"
+      "background": "Futsunushi-no-kami (\u7d4c\u6d25\u4e3b\u795e) is a Shinto deity of swords. He is regarded as the personification of the sword Futsu-no-mitama."
     },
     {
-      "name": "Michael",
+      "name": "michael",
+      "displayName": "Michael",
       "evolvesTo": null,
       "primaryElement": "Bless",
       "level": "29",
@@ -12742,31 +12945,32 @@
         },
         {
           "name": "Apt Pupil",
-          "description": "Your skill and cunning allows you to avoid the worst of impacts. You gain the following benefits:\n \u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n \u2022 You score a critical hit for attacks where all d6s in the attack roll are a 2 or less. "
+          "description": "Your skill and cunning allows you to avoid the worst of impacts. You gain the following benefits:\n\u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n\u2022 You score a critical hit for attacks where all d6s in the attack roll are a 2 or less. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Divine Judgement (24 SP, 2 actions)",
-          "description": "You call upon the decree of the heavens, which manifest as a gavel that descends and casts judgement upon a foe. Make a ranged attack against a creature within range \u000b(-1 to hit, 30 feet). On a hit, they receive bless damage equal to half of their remaining hit points. This Skill is unaffected by Concentrate."
+          "description": "You call upon the decree of the heavens, which manifest as a gavel that descends and casts judgement upon a foe. Make a ranged attack against a creature within range\n(-1 to hit, 30 feet). On a hit, they receive bless damage equal to half of their remaining hit points. This Skill is unaffected by Concentrate."
         },
         {
           "name": "Sword Dance (15 HP, 1 action)",
-          "description": "Conjured blades coil, swirl and dance in a perfect harmony, before slamming and skewering the target into smithereens. Make a melee attack against a creature within range \u000b(-1 to hit, 20 feet). On a hit, a creature receives 5d10 + 5 physical damage. This Skill scores a Critical hit if the result of each d6 in its attack roll is 5 or higher."
+          "description": "Conjured blades coil, swirl and dance in a perfect harmony, before slamming and skewering the target into smithereens. Make a melee attack against a creature within range\n(-1 to hit, 20 feet). On a hit, a creature receives 5d10 + 5 physical damage. This Skill scores a Critical hit if the result of each d6 in its attack roll is 5 or higher."
         },
         {
           "name": "Debilitate (24 SP, 1 action)",
           "description": "You forcibly impose baleful curses upon a foe, decreasing its overall combat performance. Choose a creature within range (90 feet). This creature gains the effects of Tarunda, Rakunda, and Sukunda."
         }
       ],
-      "background": "Michael, also known as Mikail in Islam, is an Archangel, one of the principal 50 angels in Christian lore, and one of the four main archangels of Abrahamic tradition.\n In Christianity, he is viewed as the field commander of the Army of God and led it in the war against the Devil and the fallen angels. He is also a saint and thus carries the title \"St. Michael The Archangel.\" He is mentioned by name in the Book of Daniel and the Book of Revelations. In the book of Daniel, Michael appears as \"one of the chief princes\" who in Daniel's vision comes to the angel Gabriel's aid in their contest with the angel of Persia, and is also described there as the advocate of Israel and \"great prince who stands up for the children of your people.\" Michael's status in the army of Heaven is seen as a Viceroy or an Archistrage as well, but he's mostly seen as the commander of Heaven's army."
+      "background": "Michael, also known as Mikail in Islam, is an Archangel, one of the principal 50 angels in Christian lore, and one of the four main archangels of Abrahamic tradition.\n\nIn Christianity, he is viewed as the field commander of the Army of God and led it in the war against the Devil and the fallen angels. He is also a saint and thus carries the title \"St. Michael The Archangel.\" He is mentioned by name in the Book of Daniel and the Book of Revelations. In the book of Daniel, Michael appears as \"one of the chief princes\" who in Daniel's vision comes to the angel Gabriel's aid in their contest with the angel of Persia, and is also described there as the advocate of Israel and \"great prince who stands up for the children of your people.\" Michael's status in the army of Heaven is seen as a Viceroy or an Archistrage as well, but he's mostly seen as the commander of Heaven's army."
     },
     {
-      "name": "Ongyo-Ki",
+      "name": "ongyo-ki",
+      "displayName": "Ongyo-Ki",
       "evolvesTo": null,
       "primaryElement": "Ailment",
       "level": "29",
@@ -12807,13 +13011,13 @@
         },
         {
           "name": "Firm Stance",
-          "description": "Resilience and durability allow you to stand firm against all threats. You gain the following benefits:\n \u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n \u2022 When you are subjected to an attack, you may choose to use this ability. If you do, you cannot evade the attack, and you receive half as much damage from it. "
+          "description": "Resilience and durability allow you to stand firm against all threats. You gain the following benefits:\n\u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n\u2022 When you are subjected to an attack, you may choose to use this ability. If you do, you cannot evade the attack, and you receive half as much damage from it. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Concealment (10 SP, 1 action)",
@@ -12828,10 +13032,11 @@
           "description": "A portal to despair yawns below a foe\u2019s feet, only to flood them in a wave of pure hatred. Make a ranged attack against a creature within range (-1 to hit, 60 feet). On a hit, they receive 4d8 + 5 curse damage."
         }
       ],
-      "background": "Ongyo Ki (\u96a0\u5f62\u9b3c) whose name means \"Invisible Oni\" was controlled by Fujiwara no Chikata (\u85e4\u539f\u5343\u65b9) from the mid-Heian period. He suppressed its aura to prevent enemies from sensing him, allowing him to surprise enemies when he attacked. It has been allegedly said that this is the origin of ninjitsu.\n"
+      "background": "Ongyo Ki (\u96a0\u5f62\u9b3c) whose name means \"Invisible Oni\" was controlled by Fujiwara no Chikata (\u85e4\u539f\u5343\u65b9) from the mid-Heian period. He suppressed its aura to prevent enemies from sensing him, allowing him to surprise enemies when he attacked. It has been allegedly said that this is the origin of ninjitsu."
     },
     {
-      "name": "Yoshitsune",
+      "name": "yoshitsune",
+      "displayName": "Yoshitsune",
       "evolvesTo": null,
       "primaryElement": "Physical",
       "level": "29",
@@ -12874,13 +13079,13 @@
         },
         {
           "name": "Retaliating Body",
-          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n \u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n \u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled. "
+          "description": "Your deft parry and reversal of force eviscerates unwary attackers. You gain the following benefits:\n\u2022 Whenever you would be targeted by a Physical or Gun Skill, roll 1d4. On a 4, you Repel that attack (see \u201cResistances\u201d in the Combat section).\n\u2022 Whenever damage would be dealt to attackers by you through an effect that Repels, the damage dealt is doubled. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -1 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: -1 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Hassou Tobi (30 HP, 2 actions)",
@@ -12888,17 +13093,18 @@
         },
         {
           "name": "Ziodyne (16 SP, 1 action)",
-          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (-1 to hit, 30 feet). On a hit, they receive \u000b3d8 + 5 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
+          "description": "Pulverizing, erratic lightning buffets a foe with a high chance of Shock. Make a ranged attack against a creature within range (-1 to hit, 30 feet). On a hit, they receive\n3d8 + 5 electric damage. If each d6 in the attack roll is a 3 or higher, the target is also Shocked (see \u201cConditions\u201d)."
         },
         {
           "name": "Power Charge (15 SP, 1 action)",
           "description": "You begin amassing your strength and stamina, coalescing into an ultimate strike. The next damage roll you make for an attack that deals Physical or Gun damage within the next 10 minutes is doubled."
         }
       ],
-      "background": "Minamoto no Yoshitsune (\u6e90 \u7fa9\u7d4c), born Ushiwakamaru (\u725b\u82e5\u4e38), was a general of the Minamoto clan during the late Heian and early Kamakura period. Yoshitsune was born in 1159 during the Heiji Rebellion (\u5e73\u6cbb\u306e\u4e71), a civil war against the rivaling Taira clan led by Kiyomori (\u5e73 \u6e05\u76db). This rebellion claimed the lives of his father Yoshitomo (\u6e90 \u7fa9\u671d) and brothers. He was put under the care of Kurama Temple. Legend says that he was trained by the mythical Kurama Tengu during this stay.\n"
+      "background": "Minamoto no Yoshitsune (\u6e90 \u7fa9\u7d4c), born Ushiwakamaru (\u725b\u82e5\u4e38), was a general of the Minamoto clan during the late Heian and early Kamakura period. Yoshitsune was born in 1159 during the Heiji Rebellion (\u5e73\u6cbb\u306e\u4e71), a civil war against the rivaling Taira clan led by Kiyomori (\u5e73 \u6e05\u76db). This rebellion claimed the lives of his father Yoshitomo (\u6e90 \u7fa9\u671d) and brothers. He was put under the care of Kurama Temple. Legend says that he was trained by the mythical Kurama Tengu during this stay."
     },
     {
-      "name": "Beelzebub",
+      "name": "beelzebub",
+      "displayName": "Beelzebub",
       "evolvesTo": null,
       "primaryElement": "Curse",
       "level": "30",
@@ -12946,7 +13152,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 2d8 + 5 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 2d8 + 5 physical damage."
         },
         {
           "name": "Death Flies (18 SP, 2 actions)",
@@ -12954,17 +13160,18 @@
         },
         {
           "name": "Demonic Decree (12 SP, 2 actions)",
-          "description": "By right of your wretched will, a scythe of malice manifests from the earth, only to slice and sunder the will of an unsuspecting foe. Make a ranged attack against a creature within range \u000b(30 feet). On a hit, they receive curse damage equal to half of their remaining hit points + 3d8. This Skill is unaffected by Concentrate."
+          "description": "By right of your wretched will, a scythe of malice manifests from the earth, only to slice and sunder the will of an unsuspecting foe. Make a ranged attack against a creature within range\n(30 feet). On a hit, they receive curse damage equal to half of their remaining hit points + 3d8. This Skill is unaffected by Concentrate."
         },
         {
           "name": "Evil Smile (10 SP, 2 actions)",
           "description": "Your wickedness is magically enhanced, sending waves of chills through all who witness. Make a ranged attack against each creature within a 20-foot radius sphere centered on a point within range (20 feet). If the result of each d6 is 2 or higher, the target is inflicted with Fear (see \u201cConditions\u201d)."
         }
       ],
-      "background": "The lord of the flies, Beelzebub was originally a Canaanite deity named Baal and was later explained to be one of the seven princes of Hell in Christian sources. He is also considered to be synonymous with Satan. In Judaism, he was a mockery of the religions surrounding them that worshipped Baal, and in Rabbinical texts the name Ba'al Zebub was a mockery of the religion of Baal. Some scholars believe the name Ba'al Zevuv (\"Lord of the Flies\") was a way of referring to Baal as a pile of dung and his followers as flies, as well as a pun on Ba'al Zebul (\"Lord of the High Place\").\n In Catholic demonology, he is sometimes considered to be one of the first three angels to fall from heaven, along with Lucifer and Leviathan. He is said to be one of the seven demon princes, and is often associated with pride, gluttony and the worship of false gods.\n"
+      "background": "The lord of the flies, Beelzebub was originally a Canaanite deity named Baal and was later explained to be one of the seven princes of Hell in Christian sources. He is also considered to be synonymous with Satan. In Judaism, he was a mockery of the religions surrounding them that worshipped Baal, and in Rabbinical texts the name Ba'al Zebub was a mockery of the religion of Baal. Some scholars believe the name Ba'al Zevuv (\"Lord of the Flies\") was a way of referring to Baal as a pile of dung and his followers as flies, as well as a pun on Ba'al Zebul (\"Lord of the High Place\").\n\nIn Catholic demonology, he is sometimes considered to be one of the first three angels to fall from heaven, along with Lucifer and Leviathan. He is said to be one of the seven demon princes, and is often associated with pride, gluttony and the worship of false gods."
     },
     {
-      "name": "Lucifer",
+      "name": "lucifer",
+      "displayName": "Lucifer",
       "evolvesTo": null,
       "primaryElement": "Almighty",
       "level": "30",
@@ -13008,7 +13215,7 @@
       "traits": [
         {
           "name": "Pinnacle of Magic",
-          "description": "You are the apex of arcana, the master of magic. You effortlessly evoke the most miraculous forces with but a gesture. You gain the following benefits:\n \u2022 Whenever you or a creature within 60 feet of you uses a Skill that deals Fire, Ice, Electric, Wind, Psychic, Nuke, Bless, Curse, or Almighty damage, you may roll 1d4. On a 4, the Spell Point cost of the Skill is halved, rounded down, to a minimum of 1."
+          "description": "You are the apex of arcana, the master of magic. You effortlessly evoke the most miraculous forces with but a gesture. You gain the following benefits:\n\u2022 Whenever you or a creature within 60 feet of you uses a Skill that deals Fire, Ice, Electric, Wind, Psychic, Nuke, Bless, Curse, or Almighty damage, you may roll 1d4. On a 4, the Spell Point cost of the Skill is halved, rounded down, to a minimum of 1."
         },
         {
           "name": "Insta-Heal",
@@ -13018,7 +13225,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 2d4 + 5 almighty damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 2d4 + 5 almighty damage."
         },
         {
           "name": "Morning Star (36 SP, 2 actions)",
@@ -13033,10 +13240,11 @@
           "description": "The aid of magic releases an ally\u2019s limiters, allowing them to fight at full potential. Choose a creature within range (90 feet). This creature gains the effects of Tarukaja, Rakukaja, and Sukukaja."
         }
       ],
-      "background": "Lucifer (Hebrew: \u05d4\u05d9\u05dc\u05dc, \"Helel\"), also known as Lucifel, is a prominent figure in Abrahamic religions, with his most infamous act being rebelling against God and subsequently falling from grace. The name Lucifer is derived from earlier Latin prose and poetry; lux, lucis, \"light,\" and fero, ferre, \"to bear, bring,\" symbolizing his role as the \"Morning Star\" and the strongest seraph or archangel, the highest ranked angel serving God prior his fall from grace. Lucifer is also the demon who represents the sin of Pride.\n While in modern literature, Lucifer and Satan are treated as the same entity, the name Lucifer was never identified with Satan until the Latin translation of the Book Isaiah. A specific passage in the book refers to a King of Babylon, who is described to have fallen from heaven and is called Helel (\"shining one\"), a name which refers to the Morning Star or Day Star (the planet Venus), which subsequently became translated as Lucifer."
+      "background": "Lucifer (Hebrew: \u05d4\u05d9\u05dc\u05dc, \"Helel\"), also known as Lucifel, is a prominent figure in Abrahamic religions, with his most infamous act being rebelling against God and subsequently falling from grace. The name Lucifer is derived from earlier Latin prose and poetry; lux, lucis, \"light,\" and fero, ferre, \"to bear, bring,\" symbolizing his role as the \"Morning Star\" and the strongest seraph or archangel, the highest ranked angel serving God prior his fall from grace. Lucifer is also the demon who represents the sin of Pride.\n\nWhile in modern literature, Lucifer and Satan are treated as the same entity, the name Lucifer was never identified with Satan until the Latin translation of the Book Isaiah. A specific passage in the book refers to a King of Babylon, who is described to have fallen from heaven and is called Helel (\"shining one\"), a name which refers to the Morning Star or Day Star (the planet Venus), which subsequently became translated as Lucifer."
     },
     {
-      "name": "Mada",
+      "name": "mada",
+      "displayName": "Mada",
       "evolvesTo": null,
       "primaryElement": "Ailment",
       "level": "30",
@@ -13086,7 +13294,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +3 to hit, range 5 ft., one target. \u000bHit: 2d6 + 5 physical damage."
+          "description": "Melee attack: +3 to hit, range 5 ft., one target.\nHit: 2d6 + 5 physical damage."
         },
         {
           "name": "Drunken Passion (15 SP, 2 actions)",
@@ -13104,7 +13312,8 @@
       "background": "In Hinduism, Mada is the monstrous deity of drunkenness. According to the Mahabhrata, it was summoned by the sage Chyavana to subdue the deity Indra. The story goes that the twin deities Asvin restored Chyavana's youthfulness when the sage rued his aged complexion and compared it to his young wife Sukanya. Feeling grateful, Chyavana told them of a feast hosted by Indra, where the gods would drink the life elixir soma to retain their immortality. Apparently Indra did not allow the twin deities to enter as they had dabbled with mortals for too long. Saddened, they reported this to the sage, who decided to offer sacrifices to the twin deities to signify their godhood. This infuriated Indra, who attacked the sage with thunderbolts and mountains. Chyavana countered by summoning Mada, who was so enormous that its two sets of jaws could swallow the earth and heavens at the same time. Indra, worried that the gods are still in the heavens, surrendered and allowed the Asvin twins to join the feast."
     },
     {
-      "name": "Maria",
+      "name": "maria",
+      "displayName": "Maria",
       "evolvesTo": null,
       "primaryElement": "Support",
       "level": "30",
@@ -13154,7 +13363,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: range 5 ft., one target. \u000bHit: 2d6 + 4 physical damage."
+          "description": "Melee attack: range 5 ft., one target.\nHit: 2d6 + 4 physical damage."
         },
         {
           "name": "Salvation (30 SP, 2 actions)",
@@ -13169,10 +13378,11 @@
           "description": "The aid of magic releases an ally\u2019s limiters, allowing them to fight at full potential. Choose a creature within range (90 feet). This creature gains the effects of Tarukaja, Rakukaja, and Sukukaja."
         }
       ],
-      "background": "Maria, known as the Virgin Mary, the Madonna, Myrhi\u00e0m or Maryam, is the central female figure in Christianity and many other Abrahamic faiths, she was a first-century Jewish woman living in the province of Galilee, wife to Joseph and mother of Jesus Christ, the messiah for Christians and a great prophet for Muslims.\n She is said in the Gospel and the Quran to have followed her son Jesus in his preachings, being an example of goodness and piety.\n In both Christianity and Islam, Maria is said to have conceived Jesus with the miraculous intervention of God, through the holy spirit (only for Christians, as Muslims do not believe in the holy trinity) after being visited by the archangel Gabriel, while maintaining her virginity. Because of this she is honored as the mother of God (theotokos in Greek) by Christians and as the greatest of all women in Islam.\n"
+      "background": "Maria, known as the Virgin Mary, the Madonna, Myrhi\u00e0m or Maryam, is the central female figure in Christianity and many other Abrahamic faiths, she was a first-century Jewish woman living in the province of Galilee, wife to Joseph and mother of Jesus Christ, the messiah for Christians and a great prophet for Muslims.\n\nShe is said in the Gospel and the Quran to have followed her son Jesus in his preachings, being an example of goodness and piety.\n\nIn both Christianity and Islam, Maria is said to have conceived Jesus with the miraculous intervention of God, through the holy spirit (only for Christians, as Muslims do not believe in the holy trinity) after being visited by the archangel Gabriel, while maintaining her virginity. Because of this she is honored as the mother of God (theotokos in Greek) by Christians and as the greatest of all women in Islam."
     },
     {
-      "name": "Metatron",
+      "name": "metatron",
+      "displayName": "Metatron",
       "evolvesTo": null,
       "primaryElement": "Bless",
       "level": "30",
@@ -13222,7 +13432,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 2d8 + 4 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 2d8 + 4 physical damage."
         },
         {
           "name": "Fire of Sinai (18 SP, 2 actions)",
@@ -13237,10 +13447,11 @@
           "description": "A flash of light. A singularity instantly expands, as a reality-busting sphere of destructive energy emerges from the ground, blinding and erasing all. Make a ranged attack against each creature within a 20-foot radius sphere centered at a point within range (20 feet). On a hit, a creature receives 4d8 + 6 almighty damage."
         }
       ],
-      "background": "Metatron (who is sometimes theorized to originally be Enoch, father of Methuselah and great-grandfather of Noah) is the voice of God. Whenever a human believes God has directly spoken to them, in reality it is Metatron acting as his vessel. One million eyes and mouths cover his body, and every mouth speaks a different language. He is the being who is the nearest in hierarchy to that of God. He is said to have the largest body among all of the angels, having 36 wings, 3 representing the triumvirate of the father (God), the son (Jesus Christ) and the holy ghost, multiplied by the 12 tribes of Israel (God's chosen people). In ancient Judaism, his status is even higher than that of the Archangel Michael.\n He received various titles such as \"Face of God,\" \"Angel of Contracts\" synonymous with the Iranian God Mithra, \"King of Angels\" and others of the like. His name literally means \"He who sits behind the throne of Heaven.\" Metatron is also said to be the twin brother of the archangel Sandalphon."
+      "background": "Metatron (who is sometimes theorized to originally be Enoch, father of Methuselah and great-grandfather of Noah) is the voice of God. Whenever a human believes God has directly spoken to them, in reality it is Metatron acting as his vessel. One million eyes and mouths cover his body, and every mouth speaks a different language. He is the being who is the nearest in hierarchy to that of God. He is said to have the largest body among all of the angels, having 36 wings, 3 representing the triumvirate of the father (God), the son (Jesus Christ) and the holy ghost, multiplied by the 12 tribes of Israel (God's chosen people). In ancient Judaism, his status is even higher than that of the Archangel Michael.\n\nHe received various titles such as \"Face of God,\" \"Angel of Contracts\" synonymous with the Iranian God Mithra, \"King of Angels\" and others of the like. His name literally means \"He who sits behind the throne of Heaven.\" Metatron is also said to be the twin brother of the archangel Sandalphon."
     },
     {
-      "name": "Satan",
+      "name": "satan",
+      "displayName": "Satan",
       "evolvesTo": null,
       "primaryElement": "Almighty",
       "level": "30",
@@ -13287,7 +13498,7 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: -2 to hit, range 5 ft., one target. \u000bHit: 2d8 + 6 physical damage."
+          "description": "Melee attack: -2 to hit, range 5 ft., one target.\nHit: 2d8 + 6 physical damage."
         },
         {
           "name": "Black Viper (36 SP, 1 action)",
@@ -13302,10 +13513,11 @@
           "description": "You gather and focus your mind's eye, delivering an absolute force of will. The next damage roll you make for an attack that deals Fire, Ice, Electric, Wind, Psychic, Nuke, Bless, Curse, or Almighty damage within the next 10 minutes is doubled."
         }
       ],
-      "background": "Satan, sometimes known as Ha-Satan, is a prominent figure in the Abrahamic religions, playing various roles in their literature. The Old Testament and Judaism describes Satan as an accuser who tempts mankind to commit sin to show God how mankind can easily be led astray from him. In the Book of Job and the Kabbalah in particular, Satan is even able to take control of the life of a person in the stead of God, though only to the extent which God allows.\n In contrast, the New Testament depicts Satan as a rebel and an opposer to the will of God. In the Gospels, he is shown trying to tempt Christ away from the role of messiah, and Jesus denounced Satan as the father of lies. The Book of Revelation later names Satan as the devil leading an army of angels into a war with Michael and the rest of heaven.\n"
+      "background": "Satan, sometimes known as Ha-Satan, is a prominent figure in the Abrahamic religions, playing various roles in their literature. The Old Testament and Judaism describes Satan as an accuser who tempts mankind to commit sin to show God how mankind can easily be led astray from him. In the Book of Job and the Kabbalah in particular, Satan is even able to take control of the life of a person in the stead of God, though only to the extent which God allows.\n\nIn contrast, the New Testament depicts Satan as a rebel and an opposer to the will of God. In the Gospels, he is shown trying to tempt Christ away from the role of messiah, and Jesus denounced Satan as the father of lies. The Book of Revelation later names Satan as the devil leading an army of angels into a war with Michael and the rest of heaven."
     },
     {
-      "name": "Izanagi-no-Okami",
+      "name": "izanagi-no-okami",
+      "displayName": "Izanagi-no-Okami",
       "evolvesTo": null,
       "primaryElement": "Almighty",
       "level": "40",
@@ -13350,11 +13562,11 @@
         },
         {
           "name": "Country Maker",
-          "description": "Your bonds are your legacy, and your true strength. You gain the following benefits:\n \u2022 As 1 action, you draw strength from your bonds. This gives you the effects of Tarukaja and Rakukaja at no cost. You may only use this ability while at least three allied creatures are within 30 feet of you. Once you use this ability, you cannot do so again until you recover from a Short Rest.\n \u2022 Whenever an allied creature within 120 feet, excluding yourself, rolls dice as part of a Trait\u2019s effect (such as Counter, Gaia Pact, Mastery of Magic, etc), you may reroll the dice once. You must use the new result."
+          "description": "Your bonds are your legacy, and your true strength. You gain the following benefits:\n\u2022 As 1 action, you draw strength from your bonds. This gives you the effects of Tarukaja and Rakukaja at no cost. You may only use this ability while at least three allied creatures are within 30 feet of you. Once you use this ability, you cannot do so again until you recover from a Short Rest.\n\u2022 Whenever an allied creature within 120 feet, excluding yourself, rolls dice as part of a Trait\u2019s effect (such as Counter, Gaia Pact, Mastery of Magic, etc), you may reroll the dice once. You must use the new result."
         },
         {
           "name": "Victory Cry",
-          "description": "Your tactical prowess grants you immense support abilities:\n \u2022 The range of Healing and Support Skills used by you is increased by 30 feet. This does not affect Skills with a range of \u201cSelf\u201d.\n \u2022 Whenever Initiative ends, all allies that acted within that Initiative regain lost Hit Points and Spell Points equal to 2d8 + your Magic. This does not affect yourself."
+          "description": "Your tactical prowess grants you immense support abilities:\n\u2022 The range of Healing and Support Skills used by you is increased by 30 feet. This does not affect Skills with a range of \u201cSelf\u201d.\n\u2022 Whenever Initiative ends, all allies that acted within that Initiative regain lost Hit Points and Spell Points equal to 2d8 + your Magic. This does not affect yourself."
         },
         {
           "name": "Elemental Amp (Almighty)",
@@ -13364,11 +13576,11 @@
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 3d6 + 6 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 3d6 + 6 physical damage."
         },
         {
           "name": "Myriad Truths (60 SP, 2 actions)",
-          "description": "Three throngs of cosmic portent emanate from your fingertips. Truth is absolute, and manifests as absolute power. Make three ranged attacks against each creature within a 20-feet radius sphere, centered at a point within range \u000b(20 feet). The first time an attack hits, each subsequent attack will use the same attack roll result as that first hit. For each hit, a creature receives 6d8 + 6 almighty damage. If the user is affected by Concentrate, the doubling effect is applied to each attack made with this Skill, instead of the first."
+          "description": "Three throngs of cosmic portent emanate from your fingertips. Truth is absolute, and manifests as absolute power. Make three ranged attacks against each creature within a 20-feet radius sphere, centered at a point within range\n(20 feet). The first time an attack hits, each subsequent attack will use the same attack roll result as that first hit. For each hit, a creature receives 6d8 + 6 almighty damage. If the user is affected by Concentrate, the doubling effect is applied to each attack made with this Skill, instead of the first."
         },
         {
           "name": "Concentrate (15 SP, 1 action)",
@@ -13383,10 +13595,11 @@
           "description": "Divine will invigorates you and your allies. Choose up to six creatures within range (90 feet). Those creatures regain 8d8 + 13 hit points. Each of those creatures recover from all Conditions."
         }
       ],
-      "background": "Izanagi-no-Ookami, named \"Ookami,\" meaning \"Great Deity,\" symbolizes Izanagi's true identity as the deity born of the seven divine generations in Japanese mythology.\n"
+      "background": "Izanagi-no-Ookami, named \"Ookami,\" meaning \"Great Deity,\" symbolizes Izanagi's true identity as the deity born of the seven divine generations in Japanese mythology."
     },
     {
-      "name": "Satanael",
+      "name": "satanael",
+      "displayName": "Satanael",
       "evolvesTo": null,
       "primaryElement": "Almighty",
       "level": "40",
@@ -13435,25 +13648,25 @@
         },
         {
           "name": "Victory Cry",
-          "description": "Your tactical prowess grants you immense support abilities:\n \u2022 The range of Healing and Support Skills used by you is increased by 30 feet. This does not affect Skills with a range of \u201cSelf\u201d.\n \u2022 Whenever Initiative ends, all allies that acted within that Initiative regain lost Hit Points and Spell Points equal to 2d8 + your Magic. This does not affect yourself."
+          "description": "Your tactical prowess grants you immense support abilities:\n\u2022 The range of Healing and Support Skills used by you is increased by 30 feet. This does not affect Skills with a range of \u201cSelf\u201d.\n\u2022 Whenever Initiative ends, all allies that acted within that Initiative regain lost Hit Points and Spell Points equal to 2d8 + your Magic. This does not affect yourself."
         },
         {
           "name": "Survival Trick",
-          "description": "With deceit and trickery, as well as resilience, you are able to avoid disaster. You gain the following benefits:\n \u2022 When you would be reduced to 0 hit points by a Hama or Mudo type Skill, or Door of Hades, you are reduced to 1 hit points instead.\n \u2022 When you would be reduced to 0 hit points by a hostile attack that is not a Hama or Mudo type Skill, or Door of Hades , you are reduced to 1 hit point instead. Once this ability is used, you cannot use it again until you fully recover in Reality."
+          "description": "With deceit and trickery, as well as resilience, you are able to avoid disaster. You gain the following benefits:\n\u2022 When you would be reduced to 0 hit points by a Hama or Mudo type Skill, or Door of Hades, you are reduced to 1 hit points instead.\n\u2022 When you would be reduced to 0 hit points by a hostile attack that is not a Hama or Mudo type Skill, or Door of Hades , you are reduced to 1 hit point instead. Once this ability is used, you cannot use it again until you fully recover in Reality."
         },
         {
           "name": "Realized Potential",
-          "description": "A new side of you manifests in and out of Reality due to your hard work in training your unexpected talents. You gain the following benefits:\n \u2022 Choose from Knowledge, Guts, Empathy, Proficiency, or Charm. The chosen Social Stat is increased by 1, up to a maximum of 5.\n \u2022 Choose from Strength, Magic, Endurance, Agility, or Luck. You gain a +2 bonus to the chosen Combat Stat."
+          "description": "A new side of you manifests in and out of Reality due to your hard work in training your unexpected talents. You gain the following benefits:\n\u2022 Choose from Knowledge, Guts, Empathy, Proficiency, or Charm. The chosen Social Stat is increased by 1, up to a maximum of 5.\n\u2022 Choose from Strength, Magic, Endurance, Agility, or Luck. You gain a +2 bonus to the chosen Combat Stat."
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 3d6 + 7 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 3d6 + 7 physical damage."
         },
         {
           "name": "Black Viper (36 SP, 1 action)",
-          "description": "You conjure the maw of a primordial serpent that arises to crush a foe into oblivion, threatening to swallow them whole. Make a ranged attack against a creature within range (+1 to hit, 90 feet). On a hit, the creature receives \u000b6d8 + 6 almighty damage."
+          "description": "You conjure the maw of a primordial serpent that arises to crush a foe into oblivion, threatening to swallow them whole. Make a ranged attack against a creature within range (+1 to hit, 90 feet). On a hit, the creature receives\n6d8 + 6 almighty damage."
         },
         {
           "name": "Megidolaon (36 SP, 2 actions)",
@@ -13461,17 +13674,18 @@
         },
         {
           "name": "Riot Gun (12 HP, 2 actions)",
-          "description": "A shower of piercing shots rain from the heavens above, turning foes into ribbons. Make a ranged attack against each creature within a 20-feet sphere, centered at a point within range (+1 to hit, 60 feet). On a hit, the creature receives \u000b5d10 + 7 gun damage."
+          "description": "A shower of piercing shots rain from the heavens above, turning foes into ribbons. Make a ranged attack against each creature within a 20-feet sphere, centered at a point within range (+1 to hit, 60 feet). On a hit, the creature receives\n5d10 + 7 gun damage."
         },
         {
           "name": "Heat Riser (24 SP, 1 action)",
           "description": "The aid of magic releases an ally\u2019s limiters, allowing them to fight at full potential. Choose a creature within range (90 feet). This creature gains the effects of Tarukaja, Rakukaja, and Sukukaja."
         }
       ],
-      "background": "Satanael, also known as Sataniel or Satanail, is an archangel mentioned in the second Book of Enoch that lead the fallen angels that rebelled against God, by refusing to bow to the human Enoch, leading to his imprisonment. Due to his name and role, he is considered an interpretation of Lucifer.\n In some Gnostic traditions, Satanael is said to be an angel that once served Yaldabaoth. He rebelled when he realized that Yaldabaoth was not the true God and granted humanity the knowledge to liberate themselves from Yaldabaoth. In other traditions, he is said to have created the material universe as a second heaven to rule over and became the \"God\" of the Old Testament, making him an interpretation of the Yaldabaoth.\n According to the beliefs of the Cathars, a notorious medieval heretical creed, Satanael (or Satanel) was the angelic name of Satan before Michael the archangel removed the -el suffix (signifying the loss of his angelic nature) and sealed him in Hell. In this interpretation, Satanael is the radical opposite of God and the ruler of the material world.\n"
+      "background": "Satanael, also known as Sataniel or Satanail, is an archangel mentioned in the second Book of Enoch that lead the fallen angels that rebelled against God, by refusing to bow to the human Enoch, leading to his imprisonment. Due to his name and role, he is considered an interpretation of Lucifer.\n\nIn some Gnostic traditions, Satanael is said to be an angel that once served Yaldabaoth. He rebelled when he realized that Yaldabaoth was not the true God and granted humanity the knowledge to liberate themselves from Yaldabaoth. In other traditions, he is said to have created the material universe as a second heaven to rule over and became the \"God\" of the Old Testament, making him an interpretation of the Yaldabaoth.\n\nAccording to the beliefs of the Cathars, a notorious medieval heretical creed, Satanael (or Satanel) was the angelic name of Satan before Michael the archangel removed the -el suffix (signifying the loss of his angelic nature) and sealed him in Hell. In this interpretation, Satanael is the radical opposite of God and the ruler of the material world."
     },
     {
-      "name": "The Reaper",
+      "name": "the-reaper",
+      "displayName": "The Reaper",
       "evolvesTo": null,
       "primaryElement": "Almighty",
       "level": "40",
@@ -13507,25 +13721,25 @@
         },
         {
           "name": "Omen",
-          "description": "You are a living embodiment of purgation. You gain the following benefits:\n \u2022 You have advantage on attacks made for Hama, Hamaon, Samsara, Mudo, Mudoon,  Die for Me!, and Door of Hades.\n \u2022 Whenever you make an attack roll for Hama, Hamaon, Samsara, Mudo, Mudoon,  Die for Me!, or Door of Hades, you may reroll any of the dice once. You must use the new result."
+          "description": "You are a living embodiment of purgation. You gain the following benefits:\n\u2022 You have advantage on attacks made for Hama, Hamaon, Samsara, Mudo, Mudoon,  Die for Me!, and Door of Hades.\n\u2022 Whenever you make an attack roll for Hama, Hamaon, Samsara, Mudo, Mudoon,  Die for Me!, or Door of Hades, you may reroll any of the dice once. You must use the new result."
         },
         {
           "name": "Hollow Jester",
-          "description": "You seek out the weak-willed and the ailing pack. You gain the following benefits:\n \u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n \u2022 You may add half your character level (min 1) to the damage roll of any attack against a target afflicted with a Condition. You may add this bonus multiple times, once for each Condition the target is inflicted with."
+          "description": "You seek out the weak-willed and the ailing pack. You gain the following benefits:\n\u2022 You may add half your character level (min 1) to the damage roll of any attack against which the target is Weak to.\n\u2022 You may add half your character level (min 1) to the damage roll of any attack against a target afflicted with a Condition. You may add this bonus multiple times, once for each Condition the target is inflicted with."
         },
         {
           "name": "Apt Pupil",
-          "description": "Your skill and cunning allows you to avoid the worst of impacts. You gain the following benefits:\n \u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n \u2022 You score a critical hit for attacks where all d6s in the attack roll are a 2 or less. "
+          "description": "Your skill and cunning allows you to avoid the worst of impacts. You gain the following benefits:\n\u2022 Whenever a creature scores a Critical hit against you from each d6 of it's attack being 6, the Critical hit becomes a normal hit.\n\u2022 You score a critical hit for attacks where all d6s in the attack roll are a 2 or less. "
         }
       ],
       "skills": [
         {
           "name": "Basic Melee Attack",
-          "description": "Melee attack: +1 to hit, range 5 ft., one target. \u000bHit: 3d6 + 6 physical damage."
+          "description": "Melee attack: +1 to hit, range 5 ft., one target.\nHit: 3d6 + 6 physical damage."
         },
         {
           "name": "Megidolaon (36 SP, 2 actions)",
-          "description": "A flash of light. A singularity instantly expands, as a reality-busting sphere of destructive energy emerges from the ground, blinding and erasing all. Make a ranged attack against each creature within a 20-foot radius sphere centered at a point within range \u000b(+1 to hit, 20 feet). On a hit, a creature receives 4d8 + 6 almighty damage."
+          "description": "A flash of light. A singularity instantly expands, as a reality-busting sphere of destructive energy emerges from the ground, blinding and erasing all. Make a ranged attack against each creature within a 20-foot radius sphere centered at a point within range\n(+1 to hit, 20 feet). On a hit, a creature receives 4d8 + 6 almighty damage."
         },
         {
           "name": "One-Shot Kill (10 HP, 1 action)",
@@ -13537,7 +13751,7 @@
         },
         {
           "name": "Hamaon (12 SP, 1 action)",
-          "description": "Divine will and an excess of banishing rights and rituals consecrate the creature\u2019s space, purging it of evil and existence. Choose a creature within range and make a ranged attack against them \u000b(+1 to hit, 90 feet). On a hit, if the result of each d6 is 3 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Bless. This Skill provokes a One More if the target is weak to Bless."
+          "description": "Divine will and an excess of banishing rights and rituals consecrate the creature\u2019s space, purging it of evil and existence. Choose a creature within range and make a ranged attack against them\n(+1 to hit, 90 feet). On a hit, if the result of each d6 is 3 or higher, the creature is reduced to 0 hit points immediately. You have advantage on attack rolls with this Skill if the creature is Weak to Bless. This Skill provokes a One More if the target is weak to Bless."
         },
         {
           "name": "Concentrate (15 SP, 1 action)",
@@ -13548,7 +13762,7 @@
           "description": "You draw upon chaotic forces to unleash upon foes. You use three of the following Skills, chosen at random: Agidyne, Bufudyne, Ziodyne, Garudyne, Psiodyne, Freidyne, or Megidola. Roll 3d8 to choose, rerolling on an 8. After the Skills are randomly chosen, you may then select targets for the Skills."
         }
       ],
-      "background": "The Reaper of the Persona series has several features that distinguish it from other \"grim reapers\" in popular culture. The Reaper, instead of carrying a gigantic scythe, wields two long-barrel revolvers. Its face is shrouded in a blood-stained cloth sack, with only one white eye exposed to see its surroundings. It wears two long chains across its left and right shoulders, forming a cross.\n The Reaper acts as a security system for areas where Shadows infest, such as Tartarus and Mementos. It either actively pursues threats as they linger in an area for too long or ambushes them inside treasure chests or other objects that might otherwise contain valuable items, such as Power Spots. In Persona Q, however, it does not act any differently than other F.O.Es. In all of its appearances, it is incredibly powerful. Boasting an extensive array of skills that ranges from Physical skills, Elemental and Almighty magic, and status and buffs, it is highly unpredictable and difficult to beat via normal means. Despite its low HP compared to most end-game bosses, its other stats are abnormally high, making it incredibly fast, durable and hard-hitting.\n Unlike most other on-field Shadows where it is encountered, the Reaper uses its own model upon spawning on the map.\n The Reaper's origins are largely unknown. However, in Persona Q alone, they are said to be deployed by Chronos to wipe out any threats against divine providence.\n"
+      "background": "The Reaper of the Persona series has several features that distinguish it from other \"grim reapers\" in popular culture. The Reaper, instead of carrying a gigantic scythe, wields two long-barrel revolvers. Its face is shrouded in a blood-stained cloth sack, with only one white eye exposed to see its surroundings. It wears two long chains across its left and right shoulders, forming a cross.\n\nThe Reaper acts as a security system for areas where Shadows infest, such as Tartarus and Mementos. It either actively pursues threats as they linger in an area for too long or ambushes them inside treasure chests or other objects that might otherwise contain valuable items, such as Power Spots. In Persona Q, however, it does not act any differently than other F.O.Es. In all of its appearances, it is incredibly powerful. Boasting an extensive array of skills that ranges from Physical skills, Elemental and Almighty magic, and status and buffs, it is highly unpredictable and difficult to beat via normal means. Despite its low HP compared to most end-game bosses, its other stats are abnormally high, making it incredibly fast, durable and hard-hitting.\n\nUnlike most other on-field Shadows where it is encountered, the Reaper uses its own model upon spawning on the map.\n\nThe Reaper's origins are largely unknown. However, in Persona Q alone, they are said to be deployed by Chronos to wipe out any threats against divine providence."
     }
   ]
 }

--- a/src/models/demon.js
+++ b/src/models/demon.js
@@ -3,6 +3,7 @@ var mongoose = require("mongoose");
 var Schema = mongoose.Schema;
 var DemonSchema = new Schema({
   name: {type: String, required: true, unique: true},
+  displayName: String,
   level: Number,
   arcana: String,
   alignment: String,
@@ -44,6 +45,18 @@ var DemonSchema = new Schema({
     }
   ],
   background: String
+},
+{
+  toJSON: { virtuals: true },
+  toObject: { virtuals: true }
+}
+);
+
+DemonSchema.virtual("evolvesToReference", {
+  ref: "Demon",
+  localField: "evolvesTo",
+  foreignField: "name",
+  justOne: true
 });
 
 module.exports = mongoose.model("Demon", DemonSchema);

--- a/src/views/details.ejs
+++ b/src/views/details.ejs
@@ -6,7 +6,7 @@
     </head>
     <body>
         <a href="/compendium/">Back to list</a>
-        <h1><%=data.name%></h1>
+        <h1><%=data.displayName%></h1>
         <div>
             Level <%=data.level%>, <%=data.arcana%>, <%=data.alignment%>, <%=data.size%> (<%=data.personality%>)
         </div>
@@ -73,18 +73,18 @@
         </div>
         <div>
             <% data.traits.forEach((trait)=>{ %>
-                <p><span><%=trait.name%>.</span>&nbsp;<span><%-trait.description.replaceAll("\n", "<br/>").replaceAll("\u000b", "<br/>");%></span></p>
+                <p><span><%=trait.name%>.</span>&nbsp;<span><%-trait.description.replaceAll("\n", "<br/>");%></span></p>
             <% }); %>
         </div>
         <div>
             Skills<br/>
             <% data.skills.forEach((skill)=>{ %>
-                <p><span><%=skill.name%>.</span>&nbsp;<span><%-skill.description.replaceAll("\n", "<br/>").replaceAll("\u000b", "<br/>");%></span></p>
+                <p><span><%=skill.name%>.</span>&nbsp;<span><%-skill.description.replaceAll("\n", "<br/>");%></span></p>
             <% }); %>
         </div>
         <div>
             <hr/>
-            <p><%-data.background.replaceAll("\n", "</p><p>").replaceAll("\u000b","</p><p>");%></p>
+            <p><%-data.background.replaceAll("\n\n", "</p><p>");%></p>
         </div>
     </body>
 </html>

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -34,11 +34,11 @@
                 <tbody>
                     <% data.forEach((item)=>{ %>
                         <tr>
-                            <td><a href="/compendium/demon/<%=item.name%>"><%= item.name %></a></td>
+                            <td><a href="/compendium/demon/<%=item.name%>"><%= item.displayName %></a></td>
                             <td><%=item.level%></td>
                             <td>
                                 <%if (item.evolvesTo !== null) {%>
-                                    <a href="/compendium/demon/<%=item.evolvesTo%>"><%=item.evolvesTo%></a>
+                                    <a href="/compendium/demon/<%=item.evolvesTo%>"><%=item.evolvesToReference.displayName%></a>
                                 <%} else {%>
                                     -
                                 <%}%>


### PR DESCRIPTION
Sanitizes the seed data for the compendium, replacing vertical tab
characters (`\u0008`) with new-line characters (`\n`). Also decouples
the display name of a demon from its canonical name (converting to all
lowercase, and replacing spaces with hyphens). This commit also updates
the model, controller, and views to consume the updated schema.