### PR TITLE
fix: Refactor code to decouple API from UI

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,8 @@ var compendiumRouter = require("./routes/compendium");
 
 app.use(express.json());
 
+app.use("/public", express.static("./public"));
+
 app.use("/", indexRouter);
 app.use("/api", apiRouter);
 app.use("/compendium", compendiumRouter);

--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -1,0 +1,54 @@
+const demonService = require("../services/demonService");
+
+// GET list of all demons
+exports.all = async function(req, res) {
+    let result = await demonService.getAllDemons();
+    if ("error" in result) {
+        res.status(404).send(JSON.stringify(result));
+        return;
+    }
+    res.send(JSON.stringify(result["demons"]));
+};
+
+// GET specific demon by name
+exports.retrieve = async function(req, res) {
+    let result = await demonService.getDemonByName(req.params.name);
+    if ("error" in result) {
+        res.status(404).send(JSON.stringify(result));
+        return;
+    }
+    res.send(JSON.stringify(result["demon"]));
+};
+
+// POST create new demon
+exports.create = async function(req, res) {
+    let result = await demonService.createDemon(req.body);
+    if ("error" in result) {
+        res.status(400).send(JSON.stringify(result));
+        return;
+    }
+    res.send(JSON.stringify(result));
+};
+
+// PUT update demon
+exports.update = async function(req, res) {
+    if (!req.body) {
+        res.status(400).send("{\"error\": \"No request body\"}")
+    }
+    let result = await demonService.updateDemon(req.params.name, req.body);
+    if ("error" in result) {
+        res.status(404).send(JSON.stringify(result));
+        return;
+    }
+    res.send(JSON.stringify(result));
+};
+
+// DELETE delete demon
+exports.delete = async function(req, res) {
+    res.send(await demonService.deleteDemon(req.params.name));
+};
+
+// DELETE delete all demons
+exports.purge = async function(req, res) {
+    res.send(await demonService.deleteAllDemons());
+};

--- a/src/controllers/demonController.js
+++ b/src/controllers/demonController.js
@@ -1,65 +1,6 @@
-var Demon = require("../models/demon");
+const querystring = require("querystring");
 
-var demonService = require("../services/demonService");
-
-// GET list of all demons
-exports.all =  async function(req, res) {
-    let demons = await demonService.getAllDemons();
-    if ("error" in demons) {
-        res.status(404).send("No demons found");
-        return;
-    }
-
-    res.send(demons["demons"]);
-};
-
-// GET specific demon by name
-exports.retrieve = async function(req, res) {
-    let demon = await(findDemon(req.params.name));
-    if (demon == null) {
-        res.status(404).send("{\"error\": \"Demon " + req.params.name + " not found\"}");
-    } else {
-        res.send(JSON.stringify(demon));
-    }
-};
-
-// POST create new demon
-exports.create = async function(req, res) {
-    try {
-        let demon = new Demon(req.body);
-        if (demon.name === "") {
-            res.status(400).send("{\"error\": \"New demon not created: Empty demon name.\"}");
-        }
-        let exists = (await Demon.find({name: req.body.name})) !== null;
-        if (exists) {
-            res.status(400).send("{\"error\": \"Demon '" + req.body.name + "' already exists.\"}");
-        } else {
-            await demon.save();
-            res.send("{\"status\": \"successful\"}");
-        }
-    } catch (err) {
-        res.status(400).send("{\"error\": \"New demon not created\"}");
-    }
-};
-
-// DELETE delete demon
-exports.delete = async function(req, res) {
-    await Demon.findOneAndDelete({name: req.params.name});
-    res.send("{\"status\": \"successful\"}");
-};
-
-// PUT update demon
-exports.update = async function(req, res) {
-    if (!req.body) {
-        res.status(400).send("{\"error\": \"No request body\"}")
-    }
-    let demon = await Demon.findOneAndUpdate({name:req.params.name}, req.body);
-    if (demon == null) {
-        res.status(404).send("{\"error\": \"Demon " + req.params.name + " not found\"}");
-    } else {
-        res.send("{\"status\": \"successful\"}");
-    }
-};
+const demonService = require("../services/demonService");
 
 // GET list of all demons
 exports.list =  async function(req, res) {
@@ -74,30 +15,31 @@ exports.list =  async function(req, res) {
 
 // GET show specific demon by name
 exports.details = async function(req, res) {
-    let demon = await(findDemon(req.params.name));
-    if (demon == null) {
-        res.send("Demon " + req.params.name + " not found");
-    } else {
-        res.render("details", {data: demon});
+    let result = await demonService.getDemonByName(req.params.name);
+    if ("error" in result) {
+        res.send(JSON.stringify(result));
+        return;
     }
+    res.render("details", { data: result["demon"] });
 };
 
 // GET edit form for specific demon by name
 exports.edit = async function(req, res) {
-    let demon = await(findDemon(req.params.name));
-    if (demon == null) {
-        res.send("Demon " + req.params.name + " not found");
-    } else {
-        let evolution = await(getEvolutions(demon.level));
-        res.render("edit", {data: demon, evolutionTargets: evolution});
+    let result = await demonService.getDemonByName(req.params.name);
+    if ("error" in result) {
+        res.send(JSON.stringify(result));
+        return;
     }
+    let demon = result["demon"];
+    let evolution = await demonService.getDemonsByLevelRange(demon.level);
+    res.render("edit", {data: demon, evolutionTargets: evolution});
 };
 
 exports.default = async function(req, res) {
-    let demon = new Demon();
-    let evolution = await(getEvolutions(0));
+    let demon = demonService.getNewDemon();
+    let evolution = await demonService.getDemonsByLevelRange(0);
     res.render("edit", {data: demon, evolutionTargets: evolution});
-}
+};
 
 // POST bulk create demons via JSON file upload
 exports.upload = async function(req, res) {
@@ -119,25 +61,6 @@ exports.upload = async function(req, res) {
     }
 };
 
-// POST build delete all demons
-exports.purge = async function(req, res) {
-    // let result = await demonService.deleteAllDemons();
-    // console.log(result);
-    // if ("error" in result) {
-    //     res.send("An error occurred deleting all demons");
-    //     return;
-    // } else {
-    //     console.log("should render me: " + result["data"]);
-    // }
-    // res.render("deleteAllComplete", { data: result["data"] });
-    let deleted = await Demon.deleteMany({});
-    res.render("deleteAllComplete", { data: deleted.deletedCount });
-};
-
-async function findDemon(name) {
-    return await Demon.findOne({name: name}).lean();
-};
-
-async function getEvolutions(level) {
-    return await Demon.find({level: {$gt: level}}, "name displayName level").sort({level: "asc", name: "asc"}).lean();
+exports.deleteAllComplete = function(req, res) {
+    res.render("deleteAllComplete", { data: req.query.deletedCount });
 };

--- a/src/public/smdg-db.css
+++ b/src/public/smdg-db.css
@@ -1,0 +1,5 @@
+
+.form-popup {
+    display: none;
+}
+  

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -1,18 +1,18 @@
 var express = require('express');
 var router = express.Router();
 
-var demonController = require("../controllers/demonController");
+var apiController = require("../controllers/apiController");
 
-router.get("/demons", demonController.all);
+router.get("/demons", apiController.all);
 
-router.get("/demon/:name", demonController.retrieve);
+router.get("/demon/:name", apiController.retrieve);
 
-router.post("/demon", demonController.create);
+router.post("/demon", apiController.create);
 
-router.put("/demon/:name", demonController.update);
+router.put("/demon/:name", apiController.update);
 
-router.delete("/demon/:name", demonController.delete);
+router.delete("/demon/:name", apiController.delete);
 
-router.delete("/demons", demonController.purge);
+router.delete("/demons", apiController.purge);
 
 module.exports = router;

--- a/src/routes/compendium.js
+++ b/src/routes/compendium.js
@@ -13,10 +13,8 @@ router.get("/demon/:name", demonController.details);
 
 router.get("/demon/:name/edit", demonController.edit);
 
-router.post("/demon/:name/delete", demonController.delete);
-
 router.post("/demon/upload", uploader.single('uploadFile'), demonController.upload);
 
-router.get("/demons/deleteall", demonController.purge);
+router.get("/demons/deleteall", demonController.deleteAllComplete);
 
 module.exports = router;

--- a/src/services/demonService.js
+++ b/src/services/demonService.js
@@ -1,0 +1,70 @@
+var Demon = require("../models/demon");
+
+exports.getAllDemons = async function getDemons() {
+    let demons = await Demon.find().sort({level: "asc", name: "asc"}).populate({
+        path: "evolvesToReference", select: "displayName name"
+    }).lean();
+    if (demons === null) {
+        return { "error": "No demons found" };
+    }
+    return { "status": "success", "demons": JSON.parse(JSON.stringify(demons)) };
+};
+
+exports.getDemonByName = async function findDemon(name) {
+    return await Demon.findOne({name: name}).lean();
+};
+
+exports.getEvolutionTargets = async function getEvolutions(level) {
+    return await Demon.find({level: {$gt: level}}, "name displayName level").sort({level: "asc", name: "asc"}).lean();
+};
+
+exports.createDemon = async function createDemon(demonToCreate) {
+    return await addNewDemon(demonToCreate);
+};
+
+exports.bulkCreateDemons = async function(demonsToAdd) {
+    console.log("Adding " + demonsToAdd.length + " demons");
+    added = 0;
+    await Promise.all(demonsToAdd.map(async (demonToAdd) => {
+        result = await addNewDemon(demonToAdd);
+        if ("status" in result && result["status"] == "success") {
+            added++;
+        }
+    }));
+    return { "status": "success", "data": added };
+};
+
+exports.deleteAllDemons = async function() {
+    let deleted = await Demon.deleteMany({});
+    return { "status": "success", "data": deleted.deletedCount };
+};
+
+exports.updateDemon = async function(demonName, demonData) {
+    let demon = await Demon.findOneAndUpdate({name:demonName}, demonData);
+    if (demon == null) {
+        return { "error": "Demon " + demonName + " not found" };
+    } else {
+        return { "status": "success" };
+    }
+};
+
+async function addNewDemon(demonToAdd) {
+    try {
+        let demon = new Demon(demonToAdd);
+        console.log("creating " + demon.name);
+        if (demon.name === "") {
+            return { "error": "New demon not created: Empty demon name."};
+        }
+        existingDemons = await Demon.find({name: demon.name});
+        let exists = existingDemons.length !== 0;
+        if (exists) {
+            return { "error": "Demon '" + demon.name + "' already exists." };
+        } else {
+            await demon.save();
+
+            return { "status": "success" };
+        }
+    } catch (err) {
+        return { "error": "New demon not created - " + err };
+    }
+};

--- a/src/views/details.ejs
+++ b/src/views/details.ejs
@@ -4,30 +4,25 @@
         <meta charset="utf-8"/>
         <title>Demon Compendium Details</title>
         <script type="text/javascript">
-            function confirmDelete(e) {
+            async function confirmDelete(e) {
                 e.preventDefault();
                 var doDelete = window.confirm("Are you sure you want to delete?");
                 if (doDelete) {
-                    let success = false;
-                    fetch("/api/demon/<%=data.name%>", {
-                        method: "DELETE",
-                        headers: {
-                            "Content-Type": "application/json"
-                        },
-                        body: "{}"
-                    }).then(response => {
+                    try {
+                        var response = await fetch("/api/demon/<%=data.name%>", {
+                            method: "DELETE",
+                            headers: {
+                                "Content-Type": "application/json"
+                            },
+                            body: "{}"
+                        });
                         if (response.ok) {
-                            success = true;
-                        }
-                        return response.json();
-                    }).then(data => {
-                        console.log(data);
-                        if (success) {
+                            var data = await response.json();
                             window.location = e.target.href;
                         }
-                    }).catch((error) => {
-                        console.log("error " + error);
-                    });
+                    } catch (err) {
+                        console.log("error: " + err);
+                    }
                 }
             }
 

--- a/src/views/edit.ejs
+++ b/src/views/edit.ejs
@@ -271,7 +271,7 @@
                 event.target.parentElement.parentElement.remove();
             }
 
-            function submitChanges(event) {
+            async function submitChanges(event) {
                 event.preventDefault();
                 let successUrl = event.target.href;
                 let displayName = document.getElementById("displayName").value;
@@ -377,26 +377,21 @@
                 data["background"] = document.getElementById("background").value;
 
                 let success = false;
-                fetch(dataUrl, {
-                    method: dataMethod,
-                    headers: {
-                        "Content-Type": "application/json"
-                    },
-                    body: JSON.stringify(data)
-                }).then(response => {
-                    console.log(response.status);
+                try {
+                    let response = await fetch(dataUrl, {
+                        method: dataMethod,
+                        headers: {
+                            "Content-Type": "application/json"
+                        },
+                        body: JSON.stringify(data)
+                    });
+                    let jsonData = await response.json();
                     if (response.ok) {
-                        success = true;
-                    }
-                    return response.json();
-                }).then(data => {
-                    console.log(data);
-                    if (success) {
                         window.location = successUrl;
                     }
-                }).catch((error) => {
-                    console.log("error " + error);
-                });
+                } catch (err) {
+                    console.log("error: " + err);
+                }
             }
         </script>
     </body>

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -4,28 +4,25 @@
         <meta charset="utf-8"/>
         <title>Demon Compendium</title>
         <script type="text/javascript">
-            function confirmDelete(e) {
+            async function confirmDelete(e) {
                 e.preventDefault();
                 var doDelete = window.confirm("Are you sure you want to delete all demons?");
                 if (doDelete) {
-                    var success = false;
-                    fetch("/api/demons", {
-                        method: "delete",
-                        headers: {
-                            "Content-Type": "application/json"
-                        },
-                        body: "{}"
-                    }).then(response => {
+                    try {
+                        var response = await fetch("/api/demons", {
+                            method: "delete",
+                            headers: {
+                                "Content-Type": "application/json"
+                            },
+                            body: "{}"
+                        });
                         if (response.ok) {
-                            success = true;
+                            var data = await response.json();
+                            window.location = e.target.href + "?deletedCount=" + data["data"];
                         }
-                        return response.json();
-                   }).then(data => {
-                        console.log(data);
-                        if (success) {
-                            window.location = e.target.href;
-                        }
-                    });
+                    } catch (err) {
+                        console.log("error: " + err);
+                    }
                 }
             }
 

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8"/>
         <title>Demon Compendium</title>
+        <link rel="stylesheet" type="text/css" href="/public/smdg-db.css" />
         <script type="text/javascript">
             async function confirmDelete(e) {
                 e.preventDefault();
@@ -26,8 +27,20 @@
                 }
             }
 
+            function showUploadForm(e) {
+                e.preventDefault();
+                document.getElementById("uploadForm").style.display = "block";
+            }
+
+            function hideUploadForm(e) {
+                e.preventDefault();
+                document.getElementById("uploadForm").style.display = "none";
+            }
+
             function addListeners() {
                 document.getElementById("deleteAll").addEventListener("click", (e) => { confirmDelete(e); });
+                document.getElementById("upload").addEventListener("click", (e) => { showUploadForm(e); });
+                document.getElementById("cancelUpload").addEventListener("click", (e) => { hideUploadForm(e); });
             }
 
             window.onload = addListeners;
@@ -35,7 +48,22 @@
     </head>
     <body>
         <h1>Shin Megami Dice Game Demon Compendium</h1>
-        <p>
+        <div>
+            <span><a id="createNew" href="/compendium/demon/new">Create new demon</a></span>&nbsp;
+            <span><a id="deleteAll" href="/compendium/demons/deleteall">Delete all demons</a></span>&nbsp;
+            <span><a id="upload" href="">Upload new data</a>
+                <div id="uploadForm" class="form-popup">
+                    <form action="/compendium/demon/upload" enctype="multipart/form-data" method="POST">
+                        <input type="file" name="uploadFile" />
+                        <input type="submit" value="Upload" />
+                        <div>
+                            <a id="cancelUpload" href="">Cancel</a>
+                        </div>
+                    </form>                    
+                </div>
+            </span>
+       </div>
+       <div>
             Currently known demons:
             <table>
                 <thead>
@@ -61,19 +89,6 @@
                     <% }); %>
                 </tbody>
             </table>
-        </p>
-        <p>
-            Upload new data:
-            <form action="/compendium/demon/upload" enctype="multipart/form-data" method="POST">
-                <input type="file" name="uploadFile">
-                <input type="submit" value="Upload">
-            </form>                    
-        </p>
-        <p>
-            <a id="deleteAll" href="/compendium/demons/deleteall">Delete all demons</a>
-        </p>
-        <p>
-            <a id="createNew" href="/compendium/demon/new">Create new demon</a>
-        </p>
+        </div>
     </body>
 </html>


### PR DESCRIPTION
This change refactors the code to decouple the UI from the API by introducing an API controller and routing all API calls through that controller instead of a single monolithic controller for both API and UI usage. A "demon service" is introduced to handle common use cases between the two where data does not flow from the UI. This is most notably true in the read-only retrieval case.

Additionally, this change moves the Fetch API calls to use the more concise `async/await` keywords, instead of chaining Promise callbacks.

Finally, it introduces the first CSS stylesheet into the project, paving the way for a richer UI, and laying the groundwork for the implementation of security for data-modifying commands,